### PR TITLE
Feature/CustomFactGroup, Custom QML

### DIFF
--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -41,8 +41,12 @@ option(QGC_ENABLE_GST_VIDEOSTREAMING "Enable GStreamer Video Backend" ON)
 option(QGC_ENABLE_QT_VIDEOSTREAMING "Enable QtMultimedia Video Backend" OFF) # Qt6Multimedia_FOUND
 
 # MAVLink
-set(QGC_MAVLINK_GIT_REPO "https://github.com/mavlink/c_library_v2.git" CACHE STRING "URL to MAVLink Git Repo")
-set(QGC_MAVLINK_GIT_TAG "19f9955598af9a9181064619bd2e3c04bd2d848a" CACHE STRING "Tag of MAVLink Git Repo")
+# set(QGC_MAVLINK_GIT_REPO "https://github.com/mavlink/c_library_v2.git" CACHE STRING "URL to MAVLink Git Repo")
+# set(QGC_MAVLINK_GIT_TAG "19f9955598af9a9181064619bd2e3c04bd2d848a" CACHE STRING "Tag of MAVLink Git Repo")
+
+# 새로운 Custom Git Repo를 참조하도록 수정
+set(QGC_MAVLINK_GIT_REPO "https://github.com/airbility-org/c_library_v2.git" CACHE STRING "URL to MAVLink Git Repo")
+set(QGC_MAVLINK_GIT_TAG "for-qgc-v5.0.1" CACHE STRING "Tag of MAVLink Git Repo")
 
 # APM
 option(QGC_DISABLE_APM_MAVLINK "Disable APM Dialect" OFF)

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -430,6 +430,9 @@
         <file alias="Viewer3D.SettingsGroup.json">src/Settings/Viewer3D.SettingsGroup.json</file>
         <file alias="GimbalController.SettingsGroup.json">src/Settings/GimbalController.SettingsGroup.json</file>
         <file alias="CameraMetaData.json">src/Camera/CameraMetaData.json</file>
+        
+        <file alias="Vehicle/FakeFactGroup.json">src/Vehicle/FactGroups/FakeFactGroup.json</file>
+        <file alias="Vehicle/CustomTiltAngleFactGroup.json">src/Vehicle/FactGroups/CustomTiltAngleFactGroup.json</file>
     </qresource>
     <qresource prefix="/MockLink">
         <file alias="APMArduSubMockLink.params">src/Comms/MockLink/APMArduSubMockLink.params</file>

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -358,6 +358,8 @@
         <file alias="DebugWindow.qml">src/UI/preferences/DebugWindow.qml</file>
         <file alias="MockLink.qml">src/UI/preferences/MockLink.qml</file>
         <file alias="MockLinkSettings.qml">src/UI/preferences/MockLinkSettings.qml</file>
+        
+        <file alias="QGroundControl/FlightDisplay/CustomDisplayPanel.qml">src/FlightDisplay/CustomDisplayPanel.qml</file>
     </qresource>
     <qresource prefix="/FirstRunPromptDialogs">
         <file alias="UnitsFirstRunPrompt.qml">src/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml</file>

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -188,11 +188,12 @@ void QGCCorePlugin::factValueGridCreateDefaultSettings(FactValueGrid* factValueG
             value->setText(value->fact()->shortDescription());
             value->setShowUnits(true);
         }
-    } else {
+    } else { // 메인 Telemetry bar과 같은 일반적인 그리드의 경우
         const bool includeFWValues = ((factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassFixedWing) || (factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassVTOL) || (factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassAirship));
 
         factValueGrid->setFontSize(FactValueGrid::LargeFontSize);
-
+        
+        // 첫 번째 줄 세 개의 열 세팅
         (void) factValueGrid->appendColumn();
         (void) factValueGrid->appendColumn();
         (void) factValueGrid->appendColumn();
@@ -275,6 +276,11 @@ QQmlApplicationEngine *QGCCorePlugin::createQmlApplicationEngine(QObject *parent
 
 void QGCCorePlugin::createRootWindow(QQmlApplicationEngine *qmlEngine)
 {
+    // qmlEngine 객체를 사용해 qml 파일을 로드
+    // load() : 인자로 주어진 경로의 qml 파일을 읽어 QML 엔진에 로드, 정의된 요소 생성
+    // QStringLiteral : 문자열 리터럴을 QString 객체로 변환하기 위해 제공하는 매크로 
+    // "qrc:/qml/MainRootWindow.qml" 이 문자열 리터럴을 QString 객체로 변환하는데 
+    // 이때 런타임 성능을 최적화해 효율적으로 처리하라는 의미
     qmlEngine->load(QUrl(QStringLiteral("qrc:/qml/MainRootWindow.qml")));
 }
 

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -105,6 +105,7 @@ Fact *FactGroup::getFact(const QString &name) const
     return fact;
 }
 
+// QString으로 지정된 name과 일치하는 FactGroup의 포인터를 반환
 FactGroup *FactGroup::getFactGroup(const QString &name) const
 {
     FactGroup * factGroup = nullptr;

--- a/src/FlightDisplay/CustomDisplayPanel.qml
+++ b/src/FlightDisplay/CustomDisplayPanel.qml
@@ -1,0 +1,87 @@
+import QtQuick
+import QtQuick.Controls
+import QtQml.Models
+
+import QGroundControl
+import QGroundControl.ScreenTools
+import QGroundControl.Controls
+import QGroundControl.FlightDisplay
+import QGroundControl.Vehicle
+
+// 애플리케이션 시작 시 CustomDisplayPanel이 로드되면서 
+// _activeVehicle에 현재 활성 차량 할당
+// 이후 활성 Vehicle이 변경될 때마다 activeVehicleChanged 시그널 발생
+// 이 시그널을 Connections에서 감지해 
+Rectangle {
+    width: 300
+    height: 200
+    color: "#1e1e1e"
+
+    property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+    Component.onCompleted: {
+        console.log("CustomDisplayPanel: _activeVehicle value:", _activeVehicle); // _activeVehicle 객체 자체를 출력
+
+        if (_activeVehicle.fake) {
+                console.log("CustomDisplayPanel: _activeVehicle.fake.dummyTiltFl:", _activeVehicle.fake.dummyTiltFl);
+                console.log("CustomDisplayPanel: _activeVehicle.fake.dummyTiltFl.valueString:", _activeVehicle.fake.dummyTiltFl.valueString);
+            } else {
+                console.log("CustomDisplayPanel: _activeVehicle.fake is NULL/UNDEFINED.");
+            }
+
+        if (_activeVehicle.tiltAngle) {
+                console.log("CustomDisplayPanel: _activeVehicle.tiltAngle.dummyTiltFl:", _activeVehicle.tiltAngle.tiltFl);
+                console.log("CustomDisplayPanel: _activeVehicle.tiltAngle.dummyTiltFl.valueString:", _activeVehicle.tiltAngle.tiltFl.valueString);
+            } else {
+                console.log("CustomDisplayPanel: _activeVehicle.tiltAngle is NULL/UNDEFINED.");
+            }
+    }
+
+    Column {
+        anchors.centerIn: parent
+        spacing: 10
+        Label {
+            text: _activeVehicle.
+        }
+
+        Label {
+            text: "Dummy Tilt FL: " + (_activeVehicle ? _activeVehicle.fake.dummyTiltFl.valueString : "--")
+            color: "white"
+        }
+
+        Label {
+            text: "Dummy Tilt FR: " + (_activeVehicle ? _activeVehicle.fake.dummyTiltFr.valueString : "--")
+            color: "white"
+        }
+
+        Label {
+            text: "Tilt Fl: " + (_activeVehicle ? _activeVehicle.tiltAngle.tiltFl.valueString : "--")
+            color: "white"
+        }
+
+        Label {
+            text: "Tilt Fr: " + (_activeVehicle ? _activeVehicle.tiltAngle.tiltFl.valueString : "--")
+            color: "white"
+        }
+
+        Label {
+            text: "Tilt Rl: " + (_activeVehicle ? _activeVehicle.tiltAngle.tiltRl.valueString : "--")
+            color: "white"
+        }
+
+        Label {
+            text: "Tilt Rr: " + (_activeVehicle ? _activeVehicle.tiltAngle.tiltRr.valueString : "--")
+            color: "white"
+        }
+
+        Button {
+            text: "테스트 값 변경"
+            onClicked: {
+                if (_activeVehicle) {
+                    _activeVehicle.fake.dummyTiltFl.value = Math.random() * 100
+                    _activeVehicle.fake.dummyTiltFr.value = Math.random() * 100
+                }
+            }
+        }
+    }
+}

--- a/src/FlightDisplay/CustomDisplayPanel.qml
+++ b/src/FlightDisplay/CustomDisplayPanel.qml
@@ -40,9 +40,6 @@ Rectangle {
     Column {
         anchors.centerIn: parent
         spacing: 10
-        Label {
-            text: _activeVehicle.
-        }
 
         Label {
             text: "Dummy Tilt FL: " + (_activeVehicle ? _activeVehicle.fake.dummyTiltFl.valueString : "--")

--- a/src/FlightDisplay/FlyView.qml
+++ b/src/FlightDisplay/FlyView.qml
@@ -30,7 +30,7 @@ import QGroundControl.Vehicle
 // 3D Viewer modules
 import Viewer3D
 
-Item {
+Item { // FlyView의 최상위 컨테이너
     id: _root
 
     // These should only be used by MainRootWindow
@@ -46,6 +46,7 @@ Item {
         Component.onCompleted:  start()
     }
 
+    // FlyView의 전역 속성들
     property bool   _mainWindowIsMap:       mapControl.pipState.state === mapControl.pipState.fullState
     property bool   _isFullWindowItemDark:  _mainWindowIsMap ? mapControl.isSatelliteMap : true
     property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
@@ -90,8 +91,8 @@ Item {
         anchors.bottom:     parent.bottom
         anchors.left:       parent.left
         anchors.right:      parent.right
-
-        FlyViewMap {
+        
+        FlyViewMap { // 비행 지도 컴포넌트
             id:                     mapControl
             planMasterController:   _planController
             rightPanelWidth:        ScreenTools.defaultFontPixelHeight * 9
@@ -123,7 +124,7 @@ Item {
             property real bottomEdgeLeftInset: visible ? height + anchors.margins : 0
         }
 
-        FlyViewWidgetLayer {
+        FlyViewWidgetLayer { // 비행 데이터를 표시하는 위젯 레이어
             id:                     widgetLayer
             anchors.top:            parent.top
             anchors.bottom:         parent.bottom

--- a/src/FlightDisplay/FlyViewInstrumentPanel.qml
+++ b/src/FlightDisplay/FlyViewInstrumentPanel.qml
@@ -12,9 +12,11 @@ import QtQuick
 import QGroundControl
 import QGroundControl.Controls
 
-SelectableControl {
+// FlyView에서 어떤 계기판을 표시할지 선택
+SelectableControl { // QGC에서 정의한 커스텀 UI 컨트롤
     z:                      QGroundControl.zOrderWidgets
     selectionUIRightAnchor: true
+    // 선택한 계기판 QML 파일의 경로를 나타내는 값
     selectedControl:        QGroundControl.settingsManager.flyViewSettings.instrumentQmlFile
 
     property var  missionController:    _missionController

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -17,7 +17,7 @@ import QtPositioning
 import QtQuick.Window
 import QtQml.Models
 
-import QGroundControl
+import QGroundControl // QGC에서 자체 정의한 컴포넌트 가져오기
 import QGroundControl.Controls
 import QGroundControl.Controllers
 import QGroundControl.Controls
@@ -32,6 +32,7 @@ import QGroundControl.Vehicle
 Item {
     id: _root
 
+    // 해당 요소가 가질 수 있는 데이터 정의
     property var    parentToolInsets
     property var    totalToolInsets:        _totalToolInsets
     property var    mapControl
@@ -95,6 +96,13 @@ Item {
         property real topEdgeRightInset:    childrenRect.height + _layoutMargin
         property real rightEdgeTopInset:    width + _layoutMargin
         property real rightEdgeCenterInset: rightEdgeTopInset
+    }
+
+    CustomDisplayPanel {
+        id:     customDisplayPanel
+        anchors.margins: _layoutMargin
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
     }
 
     FlyViewBottomRightRowLayout {

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -98,13 +98,6 @@ Item {
         property real rightEdgeCenterInset: rightEdgeTopInset
     }
 
-    CustomDisplayPanel {
-        id:     customDisplayPanel
-        anchors.margins: _layoutMargin
-        anchors.bottom: parent.bottom
-        anchors.left: parent.left
-    }
-
     FlyViewBottomRightRowLayout {
         id:                 bottomRightRowLayout
         anchors.margins:    _layoutMargin

--- a/src/FlightDisplay/TelemetryValuesBar.qml
+++ b/src/FlightDisplay/TelemetryValuesBar.qml
@@ -45,6 +45,7 @@ Item {
         RowLayout {
             visible: factValueGrid.settingsUnlocked
 
+            // 잠금 해제 상태를 나타내는 자물쇠 아이콘
             QGCColoredImage {
                 source:             "qrc:/InstrumentValueIcons/lock-open.svg"
                 mipmap:             true
@@ -61,6 +62,7 @@ Item {
             }
         }
 
+        // 데이터 값을 표시하는 그리드 컴포넌트
         HorizontalFactValueGrid {
             id: factValueGrid
         }

--- a/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
+++ b/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
@@ -28,12 +28,14 @@ Item {
     property real maxCompassRadius:             ScreenTools.defaultFontPixelHeight * 7 / 2
     property real compassRadius:                Math.min(defaultCompassRadius, maxCompassRadius)
     property real compassBorder:                ScreenTools.defaultFontPixelHeight / 2
+    // 현재 활성화된 차량 객체 참조
     property var  vehicle:                      globals.activeVehicle
     property var  qgcPal:                       QGroundControl.globalPalette
     property bool usedByMultipleVehicleList:    false
 
     property real _totalAttitudeSize: attitudeSize + attitudeSpacing
 
+    // Roll을 표시, Vehicle이 없으면 0으로 표시
     IntegratedAttitudeIndicator {
         id:                     rollIndicator
         x:                      -_totalAttitudeSize

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -267,6 +267,7 @@ void QGCApplication::init()
 {
     SettingsManager::instance()->init();
 
+    // QML 타입 등록
     LinkManager::registerQmlTypes();
     ParameterManager::registerQmlTypes();
     QGroundControlQmlGlobal::registerQmlTypes();
@@ -318,11 +319,12 @@ void QGCApplication::init()
         qCWarning(QGCApplicationLog) << "Could not load /fonts/opensans-demibold font";
     }
 
+    // 애플리케이션 모드에 따른 초기화 분기
     if (_simpleBootTest) {
         // Since GStream builds are so problematic we initialize video during the simple boot test
         // to make sure it works and verfies plugin availability.
         _initVideo();
-    } else if (!_runningUnitTests) {
+    } else if (!_runningUnitTests) { // 일반 애플리케이션 부팅 시
         _initForNormalAppBoot();
     }
 }
@@ -344,11 +346,15 @@ void QGCApplication::_initForNormalAppBoot()
     _initVideo(); // GStreamer must be initialized before QmlEngine
 
     QQuickStyle::setStyle("Basic");
+
+    // 각종 인스턴스 초기화
     QGCCorePlugin::instance()->init();
     MAVLinkProtocol::instance()->init();
     MultiVehicleManager::instance()->init();
     _qmlAppEngine = QGCCorePlugin::instance()->createQmlApplicationEngine(this);
     QObject::connect(_qmlAppEngine, &QQmlApplicationEngine::objectCreationFailed, this, QCoreApplication::quit, Qt::QueuedConnection);
+    
+    // CorePlugin을 통해 루트 윈도우(메인 UI) 생성
     QGCCorePlugin::instance()->createRootWindow(_qmlAppEngine);
 
     AudioOutput::instance()->init(SettingsManager::instance()->appSettings()->audioMuted());

--- a/src/QmlControls/FactValueGrid.cc
+++ b/src/QmlControls/FactValueGrid.cc
@@ -33,6 +33,8 @@ FactValueGrid::FactValueGrid(QQuickItem* parent)
     : QQuickItem(parent)
     , _columns  (new QmlObjectListModel(this))
 {
+    // 해당 경로의 모든 이미지 파일을 읽어와 _iconNames에 저장
+    // 계기판에서 사용할 수 있는 아이콘 목록을 한 번에 로드
     if (_iconNames.isEmpty()) {
         QDir iconDir(":/InstrumentValueIcons/");
         _iconNames = iconDir.entryList();
@@ -43,12 +45,13 @@ void FactValueGrid::componentComplete(void)
 {
     QQuickItem::componentComplete();
 
+    // fontSizeChanged 시그널 발생 시 saveSettings 호출
     connect(this, &FactValueGrid::fontSizeChanged, this, &FactValueGrid::_saveSettings);
 
     if (_specificVehicleForCard) {
         _vehicleCardInstanceList.append(this);
         _initForNewVehicle(_specificVehicleForCard);
-    } else {
+    } else { // 활성화된 비행체의 경우
         // We are not tracking a specific vehicle so we need to track the active vehicle or offline editing vehicle if not active vehicle
         auto multiVehicleManager = MultiVehicleManager::instance();
         connect(multiVehicleManager, &MultiVehicleManager::activeVehicleChanged, this, &FactValueGrid::_activeVehicleChanged);
@@ -67,6 +70,8 @@ void FactValueGrid::_initForNewVehicle(Vehicle* vehicle)
         return;
     }
 
+    // vehicleTypeChanged 시그널이 발생할때마다 
+    // _resetFromSettings 호출해 설정을 다시 로드
     connect(vehicle, &Vehicle::vehicleTypeChanged, this, &FactValueGrid::_resetFromSettings);
     _resetFromSettings();
 }
@@ -124,6 +129,7 @@ void FactValueGrid::setFontSize(FontSize fontSize)
     }
 }
 
+// InstrumentValueData 객체의 모든 속성을 QSettings에 저장
 void FactValueGrid::_saveValueData(QSettings& settings, InstrumentValueData* value)
 {
     settings.setValue(_textKey,         value->text());
@@ -153,6 +159,8 @@ void FactValueGrid::_saveValueData(QSettings& settings, InstrumentValueData* val
     settings.setValue(_factNameKey,         value->factName());
 }
 
+// QSettings에 저장된 값들을 읽어와 
+// 주어진 InstrumentValueData 객체에 설정
 void FactValueGrid::_loadValueData(QSettings& settings, InstrumentValueData* value)
 {
     QString factName = settings.value(_factNameKey).toString();
@@ -255,6 +263,7 @@ void FactValueGrid::deleteLastColumn(void)
 InstrumentValueData* FactValueGrid::_createNewInstrumentValueWorker(QObject* parent)
 {
     InstrumentValueData* value = new InstrumentValueData(this, parent);
+    // 기본으로 VehicleFactGroup의 AltitudeRelative 값을 세팅
     value->setFact(InstrumentValueData::vehicleFactGroupName, "AltitudeRelative");
     value->setText(value->fact()->shortDescription());
     _connectSaveSignals(value);
@@ -323,6 +332,7 @@ void FactValueGrid::_resetFromSettings(void)
     QSettings   settings;
     QString     groupNameFormat("%1-%2");
 
+    // 저장된 설정 (settings) 있는 경우
     if (settings.childGroups().contains(_settingsKey())) {
         // Load from settings
         settings.beginGroup(_settingsKey());
@@ -361,7 +371,7 @@ void FactValueGrid::_resetFromSettings(void)
             settings.endArray();
         }
         settings.endArray();
-    } else {
+    } else {// 기본 설정으로 초기화
         // Default settings are added directly to this FactValueGrid
         QGCCorePlugin::instance()->factValueGridCreateDefaultSettings(this);
     }

--- a/src/QmlControls/FactValueGrid.h
+++ b/src/QmlControls/FactValueGrid.h
@@ -33,7 +33,7 @@ public:
         LargeFontSize,
     };
     Q_ENUMS(FontSize)
-
+    // 표시할 Fact 객체들의 목록
     Q_PROPERTY(QmlObjectListModel*  columns         MEMBER _columns                                     NOTIFY columnsChanged)
     Q_PROPERTY(int                  rowCount        MEMBER _rowCount                                    NOTIFY rowCountChanged)
     Q_PROPERTY(QStringList          iconNames       READ iconNames                                      CONSTANT)

--- a/src/QmlControls/HorizontalFactValueGrid.qml
+++ b/src/QmlControls/HorizontalFactValueGrid.qml
@@ -20,7 +20,8 @@ import QGroundControl.Palette
 import QGroundControl.FlightMap
 import QGroundControl
 
-T.HorizontalFactValueGrid {
+// HorizontalFactValueGrid 템플릿이 내부적으로 Fact 객체를 관리하는 데이터 모델을 가지고 있음
+T.HorizontalFactValueGrid { 
     id:                     _root
     Layout.preferredWidth:  topLayout.width
     Layout.preferredHeight: topLayout.height
@@ -46,7 +47,8 @@ T.HorizontalFactValueGrid {
                 spacing:    ScreenTools.defaultFontPixelWidth * 1.25
 
                 Repeater {
-                    model: _root.columns
+                    // 자신이 가지고 있는 columns라는 이름의 model 참조
+                    model: _root.columns // Fact 객체들의 목록
 
                     GridLayout {
                         rows:           object.count
@@ -55,20 +57,27 @@ T.HorizontalFactValueGrid {
                         columnSpacing:  ScreenTools.defaultFontPixelWidth / 4
                         flow:           GridLayout.TopToBottom
 
+                        // 각 열 내부에서 InstrumentValueLabel과 InstrumentValueValue가
+                        // 한 쌍으로 표시됨
+                        // InstrumentValueLabel : e.g. "roll"
+                        // InstrumentValueValue : e.g. "12.3 deg"
                         Repeater {
                             id:     labelRepeater
-                            model:  object
+                            model:  object // 상위 Repeater의 현재 항목
 
+                            // Fact의 이름을 표시하는 QML 컴포넌트
+                            // e.g. roll, pitch
                             InstrumentValueLabel {
                                 Layout.fillHeight:      true
                                 Layout.alignment:       Qt.AlignRight
+                                // labelRepeater의 현재 항목
                                 instrumentValueData:    object
                             }
                         }
 
                         Repeater {
                             id:     valueRepeater
-                            model:  object
+                            model:  object // 상위 repeater의 현재 항목
 
                             property real   _index:     index
                             property real   maxWidth:   0
@@ -82,10 +91,12 @@ T.HorizontalFactValueGrid {
                                 maxWidth = Math.min(maxWidth, newMaxWidth)
                             }
 
+                            // Fact의 실제 값을 표시하는 QML
                             InstrumentValueValue {
                                 Layout.fillHeight:      true
                                 Layout.alignment:       Qt.AlignLeft
                                 Layout.preferredWidth:  valueRepeater.maxWidth
+                                // valueRepeater의 현재 항목
                                 instrumentValueData:    object
 
                                 property real lastContentWidth
@@ -186,7 +197,9 @@ T.HorizontalFactValueGrid {
             //console.log(mouse.x, mouse.y, columnGridLayoutItem)
             var mappedMouse = labelValueColumnLayout.mapToItem(columnGridLayoutItem, mouse.x, mouse.y)
             var labelOrDataItem = columnGridLayoutItem.childAt(mappedMouse.x, mappedMouse.y)
-            //console.log(mappedMouse.x, mappedMouse.y, labelOrDataItem, labelOrDataItem ? labelOrDataItem.instrumentValueData : "null", labelOrDataItem && labelOrDataItem.parent ? labelOrDataItem.parent.instrumentValueData : "null")
+            console.log(mappedMouse.x, mappedMouse.y, labelOrDataItem, labelOrDataItem ? labelOrDataItem.instrumentValueData : "null", labelOrDataItem && labelOrDataItem.parent ? labelOrDataItem.parent.instrumentValueData : "null")
+
+            // 클릭된 데이터의 속성 값을 팝업창에 넘겨줌
             if (labelOrDataItem && labelOrDataItem.instrumentValueData !== undefined) {
                 valueEditDialog.createObject(mainWindow, { instrumentValueData: labelOrDataItem.instrumentValueData }).open()
             }
@@ -195,7 +208,7 @@ T.HorizontalFactValueGrid {
 
     Component {
         id: valueEditDialog
-
+        // 각 항목 더블클릭 시 뜨게 되는 팝업 컴포넌트
         InstrumentValueEditDialog { }
     }
 }

--- a/src/QmlControls/InstrumentValueData.cc
+++ b/src/QmlControls/InstrumentValueData.cc
@@ -70,17 +70,25 @@ void InstrumentValueData::clearFact(void)
     emit showUnitsChanged       (_showUnits);
 }
 
+// 특정 Fact를 찾아서 연결하고  
+// 그 Fact 값 변경을 감지해 UI를 업데이트할 준비
 void InstrumentValueData::_setFactWorker(void)
 {
+    // InstrumentValueData가 이미 다른 Fact에 연결되어 있었다면
+    // 먼저 연결 해제
     if (_fact) {
         disconnect(_fact, &Fact::rawValueChanged, this, &InstrumentValueData::_updateRanges);
         _fact = nullptr;
     }
 
     FactGroup* factGroup = nullptr;
+
+    // 만약 vechicleFactGroup 이름과 같다면
+    // _vehicle 객체가 FactGroup처럼 동작
     if (_factGroupName == vehicleFactGroupName) {
         factGroup = _vehicle;
     } else {
+        // 그 외의 경우 _factGroupName 이름에 해당하는 FactGroup을 가져옴
         factGroup = _vehicle->getFactGroup(_factGroupName);
     }
 
@@ -339,7 +347,7 @@ QStringList InstrumentValueData::factGroupNames(void) const
         name[0] = name[0].toUpper();
     }
     groupNames.prepend(vehicleFactGroupName);
-
+    qDebug() << "DEBUG: Final factGroupNames (after prepend):" << groupNames; 
     return groupNames;
 }
 

--- a/src/QmlControls/InstrumentValueData.h
+++ b/src/QmlControls/InstrumentValueData.h
@@ -22,6 +22,7 @@ class InstrumentValueData : public QObject
     Q_OBJECT
 
 public:
+    // 값이 특정 범위에 있을 때 색상이나 아이콘을 바꿔주는 설정
     enum RangeType {
         NoRangeInfo = 0,
         ColorRange,
@@ -58,8 +59,8 @@ public:
     Q_INVOKABLE void    addRangeValue   (void);
     Q_INVOKABLE void    removeRangeValue(int index);
 
-    QStringList     factGroupNames          (void) const;
-    QStringList     factValueNames          (void) const;
+    QStringList     factGroupNames          (void) const; // FactGroup의 목록
+    QStringList     factValueNames          (void) const; // Fact 목록록
     QString         factGroupName           (void) const { return _factGroupName; }
     QString         factName                (void) const { return _factName; }
     Fact*           fact                    (void) const { return _fact; }
@@ -144,6 +145,7 @@ private:
 
 };
 
+// QML에서 InstrumentValueData enum을 사용할 수 있도록 등록
 QML_DECLARE_TYPE(InstrumentValueData)
 
 Q_DECLARE_METATYPE(InstrumentValueData::RangeType)

--- a/src/QmlControls/InstrumentValueEditDialog.qml
+++ b/src/QmlControls/InstrumentValueEditDialog.qml
@@ -6,7 +6,6 @@
  * COPYING.md in the root of the source code directory.
  *
  ****************************************************************************/
-
 import QtQuick
 import QtQuick.Dialogs
 import QtQuick.Layouts
@@ -25,11 +24,13 @@ QGCPopupDialog {
     title:      qsTr("Telemetry Display")
     buttons:    Dialog.Close
 
+    // HorizontalFactValueGrid 여기에서 넘겨준다.
     property var instrumentValueData
 
     QGCPalette { id: qgcPal;        colorGroupEnabled: parent.enabled }
     QGCPalette { id: qgcPalDisable; colorGroupEnabled: false }
 
+    // 조건에 따라 다른 컴포넌트를 불러오는 동적 UI
     Loader {
         sourceComponent: instrumentValueData.fact ? editorComponent : noFactComponent
     }
@@ -45,6 +46,7 @@ QGCPopupDialog {
     Component {
         id: editorComponent
 
+        // 가로 정렬
         RowLayout {
             spacing: ScreenTools.defaultFontPixelWidth
 
@@ -54,9 +56,11 @@ QGCPopupDialog {
                 SettingsGroupLayout {
                     heading: qsTr("Telemetry")
 
+                    // 드롭다운
                     LabelledComboBox {
                         id:                     factGroupCombo
-                        label:                  qsTr("Group")
+                        label:                  qsTr("Group") // Group 이라고 화면 상 표시
+                        // InstrumentValueData::factGroupNames 메서드로 FactGroup명 불러오기
                         model:                  instrumentValueData.factGroupNames
                         currentIndex:           instrumentValueData.factGroupNames.indexOf(instrumentValueData.factGroupName)
                         onActivated: (index) => {
@@ -239,6 +243,7 @@ QGCPopupDialog {
                         }
 
                         Component.onCompleted: {
+                            console.log("✅ FactGroups available:", JSON.stringify(QGroundControl.factSystem && QGroundControl.factSystem.factGroupNames ? QGroundControl.factSystem.factGroupNames : []))
                             updateSourceComponent()
                             if (sourceComponent) {
                                 height = item.childrenRect.height

--- a/src/QmlControls/QGroundControl/FlightDisplay/qmldir
+++ b/src/QmlControls/QGroundControl/FlightDisplay/qmldir
@@ -49,3 +49,5 @@ QGCVideoBackground              1.0 QGCVideoBackground.qml
 TelemetryValuesBar              1.0 TelemetryValuesBar.qml
 TerrainProgress                 1.0 TerrainProgress.qml
 VehicleWarnings                 1.0 VehicleWarnings.qml
+
+CustomDisplayPanel              1.0 CustomDisplayPanel.qml

--- a/src/UI/MainRootWindow.qml
+++ b/src/UI/MainRootWindow.qml
@@ -25,6 +25,7 @@ import QGroundControl.UTMSP
 
 /// @brief Native QML top level window
 /// All properties defined here are visible to all QML pages.
+// QtQuick.Window 모듈의 ApplicationWindow를 최상위 요소로 사용
 ApplicationWindow {
     id:             mainWindow
     minimumWidth:   ScreenTools.isMobile ? ScreenTools.screenWidth  : Math.min(ScreenTools.defaultFontPixelWidth * 100, Screen.width)
@@ -47,6 +48,7 @@ ApplicationWindow {
         firstRunPromptManager.nextPrompt()
     }
 
+    // 논리적 그룹화를 위한 QtObject
     QtObject {
         id: firstRunPromptManager
 
@@ -79,9 +81,11 @@ ApplicationWindow {
     //-------------------------------------------------------------------------
     //-- Global Scope Variables
 
+    // 전역 변수들을 캡슐화하는 QtObject
     QtObject {
-        id: globals
+        id: globals // 다른 QML에서 globals.~로 접근 가능
 
+        // 활성화된 차량 객체 (읽기 전용)
         readonly property var       activeVehicle:                  QGroundControl.multiVehicleManager.activeVehicle
         readonly property real      defaultTextHeight:              ScreenTools.defaultFontPixelHeight
         readonly property real      defaultTextWidth:               ScreenTools.defaultFontPixelWidth
@@ -110,6 +114,7 @@ ApplicationWindow {
 
     //-------------------------------------------------------------------------
     //-- Global Scope Functions
+    // 전역 범위에서 사용할 수 있는 함수 정의
 
     // This function is used to prevent view switching if there are validation errors
     function allowViewSwitch(previousValidationErrorCount = 0) {
@@ -283,7 +288,7 @@ ApplicationWindow {
     PlanView {
         id:             planView
         anchors.fill:   parent
-        visible:        false
+        visible:        false // 초기에는 화면에 보이지 않고 FlyView가 보임
     }
 
     footer: LogReplayStatusBar {

--- a/src/Vehicle/FactGroups/CMakeLists.txt
+++ b/src/Vehicle/FactGroups/CMakeLists.txt
@@ -38,6 +38,12 @@ target_sources(${CMAKE_PROJECT_NAME}
         VehicleWindFactGroup.h
         VehicleHygrometerFactGroup.cc
         VehicleHygrometerFactGroup.h
+
+        FakeFactGroup.cc
+        FakeFactGroup.h
+
+        CustomTiltAngleFactGroup.cc
+        CustomTiltAngleFactGroup.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Vehicle/FactGroups/CustomTiltAngleFactGroup.cc
+++ b/src/Vehicle/FactGroups/CustomTiltAngleFactGroup.cc
@@ -1,0 +1,36 @@
+#define MAVLINK_ENABLED_TILT_CTRL
+
+#include "CustomTiltAngleFactGroup.h"
+
+
+CustomTiltAngleFactGroup::CustomTiltAngleFactGroup(QObject* parent)
+    : FactGroup(1000, ":/json/Vehicle/CustomTiltAngleFactGroup.json", parent)
+{
+    _addFact(&_tiltFlFact, "tiltFl");
+    _addFact(&_tiltFrFact, "tiltFr");
+    _addFact(&_tiltRlFact, "tiltRl");
+    _addFact(&_tiltRrFact, "tiltRr");
+}
+
+void CustomTiltAngleFactGroup::handleMessage(Vehicle *vehicle, const mavlink_message_t &message) {
+    switch (message.msgid) {
+        case MAVLINK_MSG_ID_TILT_ANGLE: 
+            _handleTiltAngle(message);
+            break;
+            default:
+            break;
+    }
+}
+void CustomTiltAngleFactGroup::_handleTiltAngle(const mavlink_message_t &message) {
+    mavlink_tilt_angle_t tiltCtrl{}; 
+    mavlink_msg_tilt_angle_decode(&message, &tiltCtrl); 
+    _updateTiltAngle(tiltCtrl.tilt_fl, tiltCtrl.tilt_fr, tiltCtrl.tilt_rl, tiltCtrl.tilt_rr);
+
+    _setTelemetryAvailable(true); // FactGroup에 정의되어 있음
+}
+void CustomTiltAngleFactGroup::_updateTiltAngle(float fl, float fr, float rl, float rr) {
+    _tiltFlFact.setRawValue(fl);
+    _tiltFrFact.setRawValue(fr);
+    _tiltRlFact.setRawValue(rl);
+    _tiltRrFact.setRawValue(rr);
+}

--- a/src/Vehicle/FactGroups/CustomTiltAngleFactGroup.h
+++ b/src/Vehicle/FactGroups/CustomTiltAngleFactGroup.h
@@ -1,0 +1,38 @@
+#pragma once
+#include "FactGroup.h"
+
+
+class CustomTiltAngleFactGroup : public FactGroup
+{
+    Q_OBJECT
+    // QML에서 FactGroup을 사용할 수 있도록 Qt 속성으로 등록
+    // QML에서 _vehicle.tiltFl.valueString 이런 식으로 접근 가능
+    // READ tiltFl 은 아래의 Fact* tiltFl() 함수와 연결
+    Q_PROPERTY(Fact* tiltFl READ tiltFl CONSTANT)
+    Q_PROPERTY(Fact* tiltFr READ tiltFr CONSTANT)
+    Q_PROPERTY(Fact* tiltRl READ tiltRl CONSTANT)
+    Q_PROPERTY(Fact* tiltRr READ tiltRr CONSTANT)
+
+public:
+    explicit CustomTiltAngleFactGroup(QObject* parent = nullptr);
+
+    Fact* tiltFl() { return &_tiltFlFact; }
+    Fact* tiltFr() { return &_tiltFrFact; }
+    Fact* tiltRl() { return &_tiltRlFact; }
+    Fact* tiltRr() { return &_tiltRrFact; }
+
+    // Overrides from FactGroup
+    void handleMessage(Vehicle* vehicle, const mavlink_message_t& message) override;
+
+protected:
+    void _handleTiltAngle(const mavlink_message_t& message);
+
+    Fact _tiltFlFact;
+    Fact _tiltFrFact;
+    Fact _tiltRlFact;
+    Fact _tiltRrFact;
+
+private:
+    void _updateTiltAngle(float fl, float fr, float rl, float rr);
+};
+

--- a/src/Vehicle/FactGroups/CustomTiltAngleFactGroup.json
+++ b/src/Vehicle/FactGroups/CustomTiltAngleFactGroup.json
@@ -1,0 +1,31 @@
+{
+    "version":      1,
+    "fileType":  "FactMetaData",
+    "QGC.MetaData.Facts":
+[
+{
+    "name": "tiltFl",
+    "shortDesc": "Front Left Tilt",
+    "type": "float",
+    "units": "deg"
+},
+{
+    "name": "tiltFr",
+    "shortDesc": "Front Right Tilt",
+    "type": "float",
+    "units": "deg"
+},
+{
+    "name": "tiltRl",
+    "shortDesc": "Rear Left Tilt",
+    "type": "float",
+    "units": "deg"
+},
+{
+    "name": "tiltRr",
+    "shortDesc": "Rear Right Tilt",
+    "type": "float",
+    "units": "deg"
+}
+]
+}

--- a/src/Vehicle/FactGroups/FakeFactGroup.cc
+++ b/src/Vehicle/FactGroups/FakeFactGroup.cc
@@ -1,0 +1,14 @@
+#include "FakeFactGroup.h"
+
+FakeFactGroup::FakeFactGroup(QObject* parent)
+    : FactGroup(1000, ":/json/Vehicle/FakeFactGroup.json", parent)
+    // 생성자에서 JSON 파일 파싱 후 각 팩트에 대한 FactMetaData 생성
+    // _addFact 함수를 호출해 실제 Fact 인스턴스를 해당 메타데이터와 연결하고 
+    // 그룹에 추가
+{
+    _addFact(&_dummyTiltFl, "dummyTiltFl");
+    _addFact(&_dummyTiltFr, "dummyTiltFr");
+
+    _dummyTiltFl.setRawValue(42.5); // 가짜 데이터
+    _dummyTiltFr.setRawValue(20.4); // 가짜 데이터
+}

--- a/src/Vehicle/FactGroups/FakeFactGroup.h
+++ b/src/Vehicle/FactGroups/FakeFactGroup.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Fact.h"
+#include "FactGroup.h"
+
+class FakeFactGroup : public FactGroup {
+    Q_OBJECT
+    // Fact *dummyTiltFl : 정의하려는 속성의 타입과 이름
+    // 이때 지정한 이름은 QML에서 해당 값에 접근할 때 사용
+    // READ dummyTiltFl : 이 속성의 값을 읽을 때 호출될 Getter 함수 이름 지정
+    Q_PROPERTY(Fact *dummyTiltFl READ dummyTiltFl CONSTANT)
+    Q_PROPERTY(Fact *dummyTiltFr READ dummyTiltFr CONSTANT)
+public:
+    FakeFactGroup(QObject* parent = nullptr);
+
+    Fact* dummyTiltFl() { return &_dummyTiltFl; }
+    Fact* dummyTiltFr() { return &_dummyTiltFr; }
+
+private:
+    Fact _dummyTiltFl;
+    Fact _dummyTiltFr;
+};

--- a/src/Vehicle/FactGroups/FakeFactGroup.json
+++ b/src/Vehicle/FactGroups/FakeFactGroup.json
@@ -1,0 +1,19 @@
+{
+    "version":      1,
+    "fileType":  "FactMetaData",
+    "QGC.MetaData.Facts":
+[
+{
+    "name": "dummyTiltFl",
+    "shortDesc": "Front Left Tilt",
+    "type": "double",
+    "units": "deg"
+},
+{
+    "name": "dummyTiltFr",
+    "shortDesc": "Front Right Tilt",
+    "type": "double",
+    "units": "deg"
+}
+]
+}

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -90,7 +90,7 @@ Vehicle::Vehicle(LinkInterface*             link,
                  MAV_AUTOPILOT              firmwareType,
                  MAV_TYPE                   vehicleType,
                  QObject*                   parent)
-    : VehicleFactGroup              (parent)
+    : VehicleFactGroup              (parent) // Vehicle 클래스의 부모
     , _id                           (vehicleId)
     , _defaultComponentId           (defaultComponentId)
     , _firmwareType                 (firmwareType)
@@ -117,6 +117,9 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _efiFactGroup                 (this)
     , _rpmFactGroup                 (this)
     , _terrainFactGroup             (this)
+
+    , _fakeFactGroup (this)
+    , _tiltAngleFactGroup (this)
     , _terrainProtocolHandler       (new TerrainProtocolHandler(this, &_terrainFactGroup, this))
 {
     connect(JoystickManager::instance(), &JoystickManager::activeJoystickChanged, this, &Vehicle::_loadJoystickSettings);
@@ -219,6 +222,8 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _distanceSensorFactGroup          (this)
     , _localPositionFactGroup           (this)
     , _localPositionSetpointFactGroup   (this)
+    , _fakeFactGroup (this)
+    , _tiltAngleFactGroup (this)
 {
     // This will also set the settings based firmware/vehicle types. So it needs to happen first.
     if (_firmwareType == MAV_AUTOPILOT_TRACK) {
@@ -338,6 +343,9 @@ void Vehicle::_commonInit()
     _addFactGroup(&_efiFactGroup,               _efiFactGroupName);
     _addFactGroup(&_rpmFactGroup,               _rpmFactGroupName);
     _addFactGroup(&_terrainFactGroup,           _terrainFactGroupName);
+
+    _addFactGroup(&_fakeFactGroup, _fakeFactGroupName);
+    _addFactGroup(&_tiltAngleFactGroup, _tiltAngleFactGroupName);
 
     // Add firmware-specific fact groups, if provided
     QMap<QString, FactGroup*>* fwFactGroups = _firmwarePlugin->factGroups();

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -46,6 +46,9 @@
 #include "VehicleWindFactGroup.h"
 #include "GimbalController.h"
 
+#include "FakeFactGroup.h"
+#include "CustomTiltAngleFactGroup.h"
+
 class Actuators;
 class AutoPilotPlugin;
 class Autotune;
@@ -252,6 +255,8 @@ public:
 
     // FactGroup object model properties
 
+    Q_PROPERTY(FactGroup*           tiltAngle         READ tiltAngleFactGroup           CONSTANT)
+    Q_PROPERTY(FactGroup*           fake         READ fakeFactGroup           CONSTANT)
     Q_PROPERTY(FactGroup*           vehicle         READ vehicleFactGroup           CONSTANT)
     Q_PROPERTY(FactGroup*           gps             READ gpsFactGroup               CONSTANT)
     Q_PROPERTY(FactGroup*           gps2            READ gps2FactGroup              CONSTANT)
@@ -610,6 +615,9 @@ public:
     FactGroup* generatorFactGroup           () { return &_generatorFactGroup; }
     FactGroup* efiFactGroup                 () { return &_efiFactGroup; }
     FactGroup* rpmFactGroup                 () { return &_rpmFactGroup; }
+
+    FactGroup* fakeFactGroup () { return &_fakeFactGroup; }
+    FactGroup* tiltAngleFactGroup () { return &_tiltAngleFactGroup; }
     QmlObjectListModel* batteries           () { return &_batteryFactGroupListModel; }
 
     MissionManager*                 missionManager      () { return _missionManager; }
@@ -1252,6 +1260,9 @@ private:
     const QString _efiFactGroupName =                QStringLiteral("efi");
     const QString _rpmFactGroupName =                QStringLiteral("rpm");
 
+    const QString _fakeFactGroupName = QStringLiteral("fake");
+    const QString _tiltAngleFactGroupName = QStringLiteral("tiltAngle");
+
     VehicleFactGroup*               _vehicleFactGroup;
     VehicleGPSFactGroup             _gpsFactGroup;
     VehicleGPS2FactGroup            _gps2FactGroup;
@@ -1270,6 +1281,10 @@ private:
     VehicleEFIFactGroup             _efiFactGroup;
     VehicleRPMFactGroup             _rpmFactGroup;
     TerrainFactGroup                _terrainFactGroup;
+
+    FakeFactGroup _fakeFactGroup;
+    CustomTiltAngleFactGroup _tiltAngleFactGroup;
+    
     QmlObjectListModel              _batteryFactGroupListModel;
 
     TerrainProtocolHandler* _terrainProtocolHandler = nullptr;


### PR DESCRIPTION
<!--- Title -->
Add CustomTiltAngleFactGroup to support TILT_ANGLE message

Description
-----------
<!--- Describe your changes in detail. -->
Added a new CustomFactGroup (CustomTiltAngleFactGroup) to process the user-defined MAVLink message `TILT_ANGLE`. This FactGroup updates four tilt angle values (fl, fr, rl, rr) and exposes them to the QML UI.

Also added a new QML file `CustomDisplayPanel.qml` under FlyView to visualize these tilt values on screen.  
The QML reads the Facts from the vehicle object and displays real-time tilt angle updates from the incoming MAVLink stream.


Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ ] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#1 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.