### PR TITLE
add ESC HUD and ControlSurfaceCmd

### DIFF
--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink.h
@@ -1,0 +1,34 @@
+/** @file
+ *  @brief MAVLink comm protocol built from development.xml
+ *  @see http://mavlink.org
+ */
+#pragma once
+#ifndef MAVLINK_H
+#define MAVLINK_H
+
+#define MAVLINK_PRIMARY_XML_HASH -564607285555242424
+
+#ifndef MAVLINK_STX
+#define MAVLINK_STX 253
+#endif
+
+#ifndef MAVLINK_ENDIAN
+#define MAVLINK_ENDIAN MAVLINK_LITTLE_ENDIAN
+#endif
+
+#ifndef MAVLINK_ALIGNED_FIELDS
+#define MAVLINK_ALIGNED_FIELDS 1
+#endif
+
+#ifndef MAVLINK_CRC_EXTRA
+#define MAVLINK_CRC_EXTRA 1
+#endif
+
+#ifndef MAVLINK_COMMAND_24BIT
+#define MAVLINK_COMMAND_24BIT 1
+#endif
+
+#include "version.h"
+#include "development.h"
+
+#endif // MAVLINK_H

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_conversions.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_conversions.h
@@ -1,0 +1,212 @@
+#pragma once
+
+#ifndef MAVLINK_NO_CONVERSION_HELPERS
+
+/* enable math defines on Windows */
+#ifdef _MSC_VER
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+#endif
+#include <math.h>
+
+#ifndef M_PI_2
+    #define M_PI_2 ((float)asin(1))
+#endif
+
+/**
+ * @file mavlink_conversions.h
+ *
+ * These conversion functions follow the NASA rotation standards definition file
+ * available online.
+ *
+ * Their intent is to lower the barrier for MAVLink adopters to use gimbal-lock free
+ * (both rotation matrices, sometimes called DCM, and quaternions are gimbal-lock free)
+ * rotation representations. Euler angles (roll, pitch, yaw) will be phased out of the
+ * protocol as widely as possible.
+ *
+ * @author James Goppert
+ * @author Thomas Gubler <thomasgubler@gmail.com>
+ */
+
+
+/**
+ * Converts a quaternion to a rotation matrix
+ *
+ * @param quaternion a [w, x, y, z] ordered quaternion (null-rotation being 1 0 0 0)
+ * @param dcm a 3x3 rotation matrix
+ */
+MAVLINK_HELPER void mavlink_quaternion_to_dcm(const float quaternion[4], float dcm[3][3])
+{
+    double a = (double)quaternion[0];
+    double b = (double)quaternion[1];
+    double c = (double)quaternion[2];
+    double d = (double)quaternion[3];
+    double aSq = a * a;
+    double bSq = b * b;
+    double cSq = c * c;
+    double dSq = d * d;
+    dcm[0][0] = aSq + bSq - cSq - dSq;
+    dcm[0][1] = 2 * (b * c - a * d);
+    dcm[0][2] = 2 * (a * c + b * d);
+    dcm[1][0] = 2 * (b * c + a * d);
+    dcm[1][1] = aSq - bSq + cSq - dSq;
+    dcm[1][2] = 2 * (c * d - a * b);
+    dcm[2][0] = 2 * (b * d - a * c);
+    dcm[2][1] = 2 * (a * b + c * d);
+    dcm[2][2] = aSq - bSq - cSq + dSq;
+}
+
+
+/**
+ * Converts a rotation matrix to euler angles
+ *
+ * @param dcm a 3x3 rotation matrix
+ * @param roll the roll angle in radians
+ * @param pitch the pitch angle in radians
+ * @param yaw the yaw angle in radians
+ */
+MAVLINK_HELPER void mavlink_dcm_to_euler(const float dcm[3][3], float* roll, float* pitch, float* yaw)
+{
+    float phi, theta, psi;
+    theta = asinf(-dcm[2][0]);
+
+    if (fabsf(theta - (float)M_PI_2) < 1.0e-3f) {
+        phi = 0.0f;
+        psi = (atan2f(dcm[1][2] - dcm[0][1],
+                dcm[0][2] + dcm[1][1]) + phi);
+
+    } else if (fabsf(theta + (float)M_PI_2) < 1.0e-3f) {
+        phi = 0.0f;
+        psi = atan2f(dcm[1][2] - dcm[0][1],
+                  dcm[0][2] + dcm[1][1] - phi);
+
+    } else {
+        phi = atan2f(dcm[2][1], dcm[2][2]);
+        psi = atan2f(dcm[1][0], dcm[0][0]);
+    }
+
+    *roll = phi;
+    *pitch = theta;
+    *yaw = psi;
+}
+
+
+/**
+ * Converts a quaternion to euler angles
+ *
+ * @param quaternion a [w, x, y, z] ordered quaternion (null-rotation being 1 0 0 0)
+ * @param roll the roll angle in radians
+ * @param pitch the pitch angle in radians
+ * @param yaw the yaw angle in radians
+ */
+MAVLINK_HELPER void mavlink_quaternion_to_euler(const float quaternion[4], float* roll, float* pitch, float* yaw)
+{
+    float dcm[3][3];
+    mavlink_quaternion_to_dcm(quaternion, dcm);
+    mavlink_dcm_to_euler((const float(*)[3])dcm, roll, pitch, yaw);
+}
+
+
+/**
+ * Converts euler angles to a quaternion
+ *
+ * @param roll the roll angle in radians
+ * @param pitch the pitch angle in radians
+ * @param yaw the yaw angle in radians
+ * @param quaternion a [w, x, y, z] ordered quaternion (null-rotation being 1 0 0 0)
+ */
+MAVLINK_HELPER void mavlink_euler_to_quaternion(float roll, float pitch, float yaw, float quaternion[4])
+{
+    float cosPhi_2 = cosf(roll / 2);
+    float sinPhi_2 = sinf(roll / 2);
+    float cosTheta_2 = cosf(pitch / 2);
+    float sinTheta_2 = sinf(pitch / 2);
+    float cosPsi_2 = cosf(yaw / 2);
+    float sinPsi_2 = sinf(yaw / 2);
+    quaternion[0] = (cosPhi_2 * cosTheta_2 * cosPsi_2 +
+            sinPhi_2 * sinTheta_2 * sinPsi_2);
+    quaternion[1] = (sinPhi_2 * cosTheta_2 * cosPsi_2 -
+            cosPhi_2 * sinTheta_2 * sinPsi_2);
+    quaternion[2] = (cosPhi_2 * sinTheta_2 * cosPsi_2 +
+            sinPhi_2 * cosTheta_2 * sinPsi_2);
+    quaternion[3] = (cosPhi_2 * cosTheta_2 * sinPsi_2 -
+            sinPhi_2 * sinTheta_2 * cosPsi_2);
+}
+
+
+/**
+ * Converts a rotation matrix to a quaternion
+ * Reference:
+ *  - Shoemake, Quaternions,
+ *  http://www.cs.ucr.edu/~vbz/resources/quatut.pdf
+ *
+ * @param dcm a 3x3 rotation matrix
+ * @param quaternion a [w, x, y, z] ordered quaternion (null-rotation being 1 0 0 0)
+ */
+MAVLINK_HELPER void mavlink_dcm_to_quaternion(const float dcm[3][3], float quaternion[4])
+{
+    float tr = dcm[0][0] + dcm[1][1] + dcm[2][2];
+    if (tr > 0.0f) {
+        float s = sqrtf(tr + 1.0f);
+        quaternion[0] = s * 0.5f;
+        s = 0.5f / s;
+        quaternion[1] = (dcm[2][1] - dcm[1][2]) * s;
+        quaternion[2] = (dcm[0][2] - dcm[2][0]) * s;
+        quaternion[3] = (dcm[1][0] - dcm[0][1]) * s;
+    } else {
+        /* Find maximum diagonal element in dcm
+         * store index in dcm_i */
+        int dcm_i = 0;
+        int i;
+        for (i = 1; i < 3; i++) {
+            if (dcm[i][i] > dcm[dcm_i][dcm_i]) {
+                dcm_i = i;
+            }
+        }
+
+        int dcm_j = (dcm_i + 1) % 3;
+        int dcm_k = (dcm_i + 2) % 3;
+
+        float s = sqrtf((dcm[dcm_i][dcm_i] - dcm[dcm_j][dcm_j] -
+                    dcm[dcm_k][dcm_k]) + 1.0f);
+        quaternion[dcm_i + 1] = s * 0.5f;
+        s = 0.5f / s;
+        quaternion[dcm_j + 1] = (dcm[dcm_i][dcm_j] + dcm[dcm_j][dcm_i]) * s;
+        quaternion[dcm_k + 1] = (dcm[dcm_k][dcm_i] + dcm[dcm_i][dcm_k]) * s;
+        quaternion[0] = (dcm[dcm_k][dcm_j] - dcm[dcm_j][dcm_k]) * s;
+    }
+}
+
+
+/**
+ * Converts euler angles to a rotation matrix
+ *
+ * @param roll the roll angle in radians
+ * @param pitch the pitch angle in radians
+ * @param yaw the yaw angle in radians
+ * @param dcm a 3x3 rotation matrix
+ */
+MAVLINK_HELPER void mavlink_euler_to_dcm(float roll, float pitch, float yaw, float dcm[3][3])
+{
+    float cosPhi = cosf(roll);
+    float sinPhi = sinf(roll);
+    float cosThe = cosf(pitch);
+    float sinThe = sinf(pitch);
+    float cosPsi = cosf(yaw);
+    float sinPsi = sinf(yaw);
+
+    dcm[0][0] = cosThe * cosPsi;
+    dcm[0][1] = -cosPhi * sinPsi + sinPhi * sinThe * cosPsi;
+    dcm[0][2] = sinPhi * sinPsi + cosPhi * sinThe * cosPsi;
+
+    dcm[1][0] = cosThe * sinPsi;
+    dcm[1][1] = cosPhi * cosPsi + sinPhi * sinThe * sinPsi;
+    dcm[1][2] = -sinPhi * cosPsi + cosPhi * sinThe * sinPsi;
+
+    dcm[2][0] = -sinThe;
+    dcm[2][1] = sinPhi * cosThe;
+    dcm[2][2] = cosPhi * cosThe;
+}
+
+#endif // MAVLINK_NO_CONVERSION_HELPERS

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_get_info.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_get_info.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#ifdef MAVLINK_USE_MESSAGE_INFO
+#define MAVLINK_HAVE_GET_MESSAGE_INFO
+
+/*
+  return the message_info struct for a message
+*/
+MAVLINK_HELPER const mavlink_message_info_t *mavlink_get_message_info_by_id(uint32_t msgid)
+{
+	static const mavlink_message_info_t mavlink_message_info[] = MAVLINK_MESSAGE_INFO;
+	/*
+	  use a bisection search to find the right entry. A perfect hash may be better
+	  Note that this assumes the table is sorted with primary key msgid
+	*/
+	const uint32_t count = sizeof(mavlink_message_info)/sizeof(mavlink_message_info[0]);
+	if (count == 0) {
+		return NULL;
+	}
+	uint32_t low=0, high=count-1;
+	while (low < high) {
+		uint32_t mid = (low+high)/2;
+		if (msgid < mavlink_message_info[mid].msgid) {
+			high = mid;
+			continue;
+		}
+		if (msgid > mavlink_message_info[mid].msgid) {
+			low = mid+1;
+			continue;
+		}
+		return &mavlink_message_info[mid];
+	}
+	if (mavlink_message_info[low].msgid == msgid) {
+		return &mavlink_message_info[low];
+	}
+	return NULL;
+}
+
+/*
+  return the message_info struct for a message
+*/
+MAVLINK_HELPER const mavlink_message_info_t *mavlink_get_message_info(const mavlink_message_t *msg)
+{
+    return mavlink_get_message_info_by_id(msg->msgid);
+}
+
+/*
+  return the message_info struct for a message
+*/
+MAVLINK_HELPER const mavlink_message_info_t *mavlink_get_message_info_by_name(const char *name)
+{
+	static const struct { const char *name; uint32_t msgid; } mavlink_message_names[] = MAVLINK_MESSAGE_NAMES;
+	/*
+	  use a bisection search to find the right entry. A perfect hash may be better
+	  Note that this assumes the table is sorted with primary key name
+	*/
+	const uint32_t count = sizeof(mavlink_message_names)/sizeof(mavlink_message_names[0]);
+	if (count == 0) {
+		return NULL;
+	}
+	uint32_t low=0, high=count-1;
+	while (low < high) {
+		uint32_t mid = (low+high)/2;
+		int cmp = strcmp(mavlink_message_names[mid].name, name);
+		if (cmp > 0) {
+			high = mid;
+			continue;
+		}
+		if (cmp < 0) {
+			low = mid+1;
+			continue;
+		}
+		low = mid;
+		break;
+	}
+	if (strcmp(mavlink_message_names[low].name, name) == 0) {
+		return mavlink_get_message_info_by_id(mavlink_message_names[low].msgid);
+	}
+	return NULL;
+}
+#endif // MAVLINK_USE_MESSAGE_INFO
+
+

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_helpers.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_helpers.h
@@ -1,0 +1,1152 @@
+#pragma once
+
+#include "string.h"
+#include "checksum.h"
+#include "mavlink_types.h"
+#include "mavlink_conversions.h"
+#include <stdio.h>
+
+#ifndef MAVLINK_HELPER
+#define MAVLINK_HELPER
+#endif
+
+#include "mavlink_sha256.h"
+
+#ifdef MAVLINK_USE_CXX_NAMESPACE
+namespace mavlink {
+#endif
+
+/*
+ * Internal function to give access to the channel status for each channel
+ */
+#ifndef MAVLINK_GET_CHANNEL_STATUS
+MAVLINK_HELPER mavlink_status_t* mavlink_get_channel_status(uint8_t chan)
+{
+#ifdef MAVLINK_EXTERNAL_RX_STATUS
+	// No m_mavlink_status array defined in function,
+	// has to be defined externally
+#else
+	static mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
+#endif
+	return &m_mavlink_status[chan];
+}
+#endif
+
+/*
+ * Internal function to give access to the channel buffer for each channel
+ */
+#ifndef MAVLINK_GET_CHANNEL_BUFFER
+MAVLINK_HELPER mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan)
+{
+	
+#ifdef MAVLINK_EXTERNAL_RX_BUFFER
+	// No m_mavlink_buffer array defined in function,
+	// has to be defined externally
+#else
+	static mavlink_message_t m_mavlink_buffer[MAVLINK_COMM_NUM_BUFFERS];
+#endif
+	return &m_mavlink_buffer[chan];
+}
+#endif // MAVLINK_GET_CHANNEL_BUFFER
+
+/* Enable this option to check the length of each message.
+    This allows invalid messages to be caught much sooner. Use if the transmission
+    medium is prone to missing (or extra) characters (e.g. a radio that fades in
+    and out). Only use if the channel will only contain messages types listed in
+    the headers.
+*/
+//#define MAVLINK_CHECK_MESSAGE_LENGTH
+
+/**
+ * @brief Reset the status of a channel.
+ */
+MAVLINK_HELPER void mavlink_reset_channel_status(uint8_t chan)
+{
+	mavlink_status_t *status = mavlink_get_channel_status(chan);
+	status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+}
+
+#ifndef MAVLINK_NO_SIGN_PACKET
+/**
+ * @brief create a signature block for a packet
+ */
+MAVLINK_HELPER uint8_t mavlink_sign_packet(mavlink_signing_t *signing,
+					   uint8_t signature[MAVLINK_SIGNATURE_BLOCK_LEN],
+					   const uint8_t *header, uint8_t header_len,
+					   const uint8_t *packet, uint8_t packet_len,
+					   const uint8_t crc[2])
+{
+	mavlink_sha256_ctx ctx;
+	union {
+	    uint64_t t64;
+	    uint8_t t8[8];
+	} tstamp;
+	if (signing == NULL || !(signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING)) {
+	    return 0;
+	}
+	signature[0] = signing->link_id;
+	tstamp.t64 = signing->timestamp;
+	memcpy(&signature[1], tstamp.t8, 6);
+	signing->timestamp++;
+	
+	mavlink_sha256_init(&ctx);
+	mavlink_sha256_update(&ctx, signing->secret_key, sizeof(signing->secret_key));
+	mavlink_sha256_update(&ctx, header, header_len);
+	mavlink_sha256_update(&ctx, packet, packet_len);
+	mavlink_sha256_update(&ctx, crc, 2);
+	mavlink_sha256_update(&ctx, signature, 7);
+	mavlink_sha256_final_48(&ctx, &signature[7]);
+	
+	return MAVLINK_SIGNATURE_BLOCK_LEN;
+}
+#endif
+
+/**
+ * @brief Trim payload of any trailing zero-populated bytes (MAVLink 2 only).
+ *
+ * @param payload Serialised payload buffer.
+ * @param length Length of full-width payload buffer.
+ * @return Length of payload after zero-filled bytes are trimmed.
+ */
+MAVLINK_HELPER uint8_t _mav_trim_payload(const char *payload, uint8_t length)
+{
+	while (length > 1 && payload[length-1] == 0) {
+		length--;
+	}
+	return length;
+}
+
+#ifndef MAVLINK_NO_SIGNATURE_CHECK
+/**
+ * @brief check a signature block for a packet
+ */
+MAVLINK_HELPER bool mavlink_signature_check(mavlink_signing_t *signing,
+					    mavlink_signing_streams_t *signing_streams,
+					    const mavlink_message_t *msg)
+{
+	if (signing == NULL) {
+		return true;
+	}
+        const uint8_t *p = (const uint8_t *)&msg->magic;
+	const uint8_t *psig = msg->signature;
+        const uint8_t *incoming_signature = psig+7;
+	mavlink_sha256_ctx ctx;
+	uint8_t signature[6];
+	uint16_t i;
+        
+	mavlink_sha256_init(&ctx);
+	mavlink_sha256_update(&ctx, signing->secret_key, sizeof(signing->secret_key));
+	mavlink_sha256_update(&ctx, p, MAVLINK_NUM_HEADER_BYTES);
+	mavlink_sha256_update(&ctx, _MAV_PAYLOAD(msg), msg->len);
+	mavlink_sha256_update(&ctx, msg->ck, 2);
+	mavlink_sha256_update(&ctx, psig, 1+6);
+	mavlink_sha256_final_48(&ctx, signature);
+        if (memcmp(signature, incoming_signature, 6) != 0) {
+                signing->last_status = MAVLINK_SIGNING_STATUS_BAD_SIGNATURE;
+		return false;
+	}
+
+	// now check timestamp
+	union tstamp {
+	    uint64_t t64;
+	    uint8_t t8[8];
+	} tstamp;
+	uint8_t link_id = psig[0];
+	tstamp.t64 = 0;
+	memcpy(tstamp.t8, psig+1, 6);
+
+	if (signing_streams == NULL) {
+                signing->last_status = MAVLINK_SIGNING_STATUS_NO_STREAMS;
+                return false;
+	}
+	
+	// find stream
+	for (i=0; i<signing_streams->num_signing_streams; i++) {
+		if (msg->sysid == signing_streams->stream[i].sysid &&
+		    msg->compid == signing_streams->stream[i].compid &&
+		    link_id == signing_streams->stream[i].link_id) {
+			break;
+		}
+	}
+	if (i == signing_streams->num_signing_streams) {
+		if (signing_streams->num_signing_streams >= MAVLINK_MAX_SIGNING_STREAMS) {
+			// over max number of streams
+                        signing->last_status = MAVLINK_SIGNING_STATUS_TOO_MANY_STREAMS;
+                        return false;
+		}
+		// new stream. Only accept if timestamp is not more than 1 minute old
+		if (tstamp.t64 + 6000*1000UL < signing->timestamp) {
+                        signing->last_status = MAVLINK_SIGNING_STATUS_OLD_TIMESTAMP;
+                        return false;
+		}
+		// add new stream
+		signing_streams->stream[i].sysid = msg->sysid;
+		signing_streams->stream[i].compid = msg->compid;
+		signing_streams->stream[i].link_id = link_id;
+		signing_streams->num_signing_streams++;
+	} else {
+		union tstamp last_tstamp;
+		last_tstamp.t64 = 0;
+		memcpy(last_tstamp.t8, signing_streams->stream[i].timestamp_bytes, 6);
+		if (tstamp.t64 <= last_tstamp.t64) {
+			// repeating old timestamp
+                        signing->last_status = MAVLINK_SIGNING_STATUS_REPLAY;
+                        return false;
+		}
+	}
+
+	// remember last timestamp
+	memcpy(signing_streams->stream[i].timestamp_bytes, psig+1, 6);
+
+	// our next timestamp must be at least this timestamp
+	if (tstamp.t64 > signing->timestamp) {
+		signing->timestamp = tstamp.t64;
+	}
+        signing->last_status = MAVLINK_SIGNING_STATUS_OK;
+        return true;
+}
+#endif
+
+
+/**
+ * @brief Finalize a MAVLink message with channel assignment
+ *
+ * This function calculates the checksum and sets length and aircraft id correctly.
+ * It assumes that the message id and the payload are already correctly set. This function
+ * can also be used if the message header has already been written before (as in mavlink_msg_xxx_pack
+ * instead of mavlink_msg_xxx_pack_headerless), it just introduces little extra overhead.
+ *
+ * @param msg Message to finalize
+ * @param system_id Id of the sending (this) system, 1-127
+ * @param length Message length
+ */
+MAVLINK_HELPER uint16_t mavlink_finalize_message_buffer(mavlink_message_t* msg, uint8_t system_id, uint8_t component_id,
+						      mavlink_status_t* status, uint8_t min_length, uint8_t length, uint8_t crc_extra)
+{
+	bool mavlink1 = (status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) != 0;
+#ifndef MAVLINK_NO_SIGN_PACKET
+	bool signing = 	(!mavlink1) && status->signing && (status->signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING);
+#else
+	bool signing = false;
+#endif
+	uint8_t signature_len = signing? MAVLINK_SIGNATURE_BLOCK_LEN : 0;
+        uint8_t header_len = MAVLINK_CORE_HEADER_LEN+1;
+	uint8_t buf[MAVLINK_CORE_HEADER_LEN+1];
+	if (mavlink1) {
+		msg->magic = MAVLINK_STX_MAVLINK1;
+		header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN+1;
+	} else {
+		msg->magic = MAVLINK_STX;
+	}
+	msg->len = mavlink1?min_length:_mav_trim_payload(_MAV_PAYLOAD(msg), length);
+	msg->sysid = system_id;
+	msg->compid = component_id;
+	msg->incompat_flags = 0;
+	if (signing) {
+		msg->incompat_flags |= MAVLINK_IFLAG_SIGNED;
+	}
+	msg->compat_flags = 0;
+	msg->seq = status->current_tx_seq;
+	status->current_tx_seq = status->current_tx_seq + 1;
+
+	// form the header as a byte array for the crc
+	buf[0] = msg->magic;
+	buf[1] = msg->len;
+	if (mavlink1) {
+		buf[2] = msg->seq;
+		buf[3] = msg->sysid;
+		buf[4] = msg->compid;
+		buf[5] = msg->msgid & 0xFF;
+	} else {
+		buf[2] = msg->incompat_flags;
+		buf[3] = msg->compat_flags;
+		buf[4] = msg->seq;
+		buf[5] = msg->sysid;
+		buf[6] = msg->compid;
+		buf[7] = msg->msgid & 0xFF;
+		buf[8] = (msg->msgid >> 8) & 0xFF;
+		buf[9] = (msg->msgid >> 16) & 0xFF;
+	}
+	
+	uint16_t checksum = crc_calculate(&buf[1], header_len-1);
+	crc_accumulate_buffer(&checksum, _MAV_PAYLOAD(msg), msg->len);
+	crc_accumulate(crc_extra, &checksum);
+	mavlink_ck_a(msg) = (uint8_t)(checksum & 0xFF);
+	mavlink_ck_b(msg) = (uint8_t)(checksum >> 8);
+
+	msg->checksum = checksum;
+
+#ifndef MAVLINK_NO_SIGN_PACKET
+	if (signing) {
+		mavlink_sign_packet(status->signing,
+				    msg->signature,
+				    (const uint8_t *)buf, header_len,
+				    (const uint8_t *)_MAV_PAYLOAD(msg), msg->len,
+				    (const uint8_t *)_MAV_PAYLOAD(msg)+(uint16_t)msg->len);
+	}
+#endif
+
+	return msg->len + header_len + 2 + signature_len;
+}
+
+MAVLINK_HELPER uint16_t mavlink_finalize_message_chan(mavlink_message_t* msg, uint8_t system_id, uint8_t component_id,
+						      uint8_t chan, uint8_t min_length, uint8_t length, uint8_t crc_extra)
+{
+	mavlink_status_t *status = mavlink_get_channel_status(chan);
+	return mavlink_finalize_message_buffer(msg, system_id, component_id, status, min_length, length, crc_extra);
+}
+
+/**
+ * @brief Finalize a MAVLink message with MAVLINK_COMM_0 as default channel
+ */
+MAVLINK_HELPER uint16_t mavlink_finalize_message(mavlink_message_t* msg, uint8_t system_id, uint8_t component_id, 
+						 uint8_t min_length, uint8_t length, uint8_t crc_extra)
+{
+    return mavlink_finalize_message_chan(msg, system_id, component_id, MAVLINK_COMM_0, min_length, length, crc_extra);
+}
+
+static inline void _mav_parse_error(mavlink_status_t *status)
+{
+    status->parse_error++;
+}
+
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+MAVLINK_HELPER void _mavlink_send_uart(mavlink_channel_t chan, const char *buf, uint16_t len);
+
+/**
+ * @brief Finalize a MAVLink message with channel assignment and send
+ */
+MAVLINK_HELPER void _mav_finalize_message_chan_send(mavlink_channel_t chan, uint32_t msgid,
+                                                    const char *packet, 
+						    uint8_t min_length, uint8_t length, uint8_t crc_extra)
+{
+	uint16_t checksum;
+	uint8_t buf[MAVLINK_NUM_HEADER_BYTES];
+	uint8_t ck[2];
+	mavlink_status_t *status = mavlink_get_channel_status(chan);
+        uint8_t header_len = MAVLINK_CORE_HEADER_LEN;
+	uint8_t signature_len = 0;
+	uint8_t signature[MAVLINK_SIGNATURE_BLOCK_LEN];
+	bool mavlink1 = (status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) != 0;
+	bool signing = 	(!mavlink1) && status->signing && (status->signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING);
+
+        if (mavlink1) {
+            length = min_length;
+            if (msgid > 255) {
+                // can't send 16 bit messages
+                _mav_parse_error(status);
+                return;
+            }
+            header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN;
+            buf[0] = MAVLINK_STX_MAVLINK1;
+            buf[1] = length;
+            buf[2] = status->current_tx_seq;
+            buf[3] = mavlink_system.sysid;
+            buf[4] = mavlink_system.compid;
+            buf[5] = msgid & 0xFF;
+        } else {
+	    uint8_t incompat_flags = 0;
+	    if (signing) {
+		incompat_flags |= MAVLINK_IFLAG_SIGNED;
+	    }
+            length = _mav_trim_payload(packet, length);
+            buf[0] = MAVLINK_STX;
+            buf[1] = length;
+            buf[2] = incompat_flags;
+            buf[3] = 0; // compat_flags
+            buf[4] = status->current_tx_seq;
+            buf[5] = mavlink_system.sysid;
+            buf[6] = mavlink_system.compid;
+            buf[7] = msgid & 0xFF;
+            buf[8] = (msgid >> 8) & 0xFF;
+            buf[9] = (msgid >> 16) & 0xFF;
+        }
+	status->current_tx_seq++;
+	checksum = crc_calculate((const uint8_t*)&buf[1], header_len);
+	crc_accumulate_buffer(&checksum, packet, length);
+	crc_accumulate(crc_extra, &checksum);
+	ck[0] = (uint8_t)(checksum & 0xFF);
+	ck[1] = (uint8_t)(checksum >> 8);
+
+	if (signing) {
+		// possibly add a signature
+		signature_len = mavlink_sign_packet(status->signing, signature, buf, header_len+1,
+						    (const uint8_t *)packet, length, ck);
+	}
+	
+	MAVLINK_START_UART_SEND(chan, header_len + 3 + (uint16_t)length + (uint16_t)signature_len);
+	_mavlink_send_uart(chan, (const char *)buf, header_len+1);
+	_mavlink_send_uart(chan, packet, length);
+	_mavlink_send_uart(chan, (const char *)ck, 2);
+	if (signature_len != 0) {
+		_mavlink_send_uart(chan, (const char *)signature, signature_len);
+	}
+	MAVLINK_END_UART_SEND(chan, header_len + 3 + (uint16_t)length + (uint16_t)signature_len);
+}
+
+/**
+ * @brief re-send a message over a uart channel
+ * this is more stack efficient than re-marshalling the message
+ * If the message is signed then the original signature is also sent
+ */
+MAVLINK_HELPER void _mavlink_resend_uart(mavlink_channel_t chan, const mavlink_message_t *msg)
+{
+	uint8_t ck[2];
+
+	ck[0] = (uint8_t)(msg->checksum & 0xFF);
+	ck[1] = (uint8_t)(msg->checksum >> 8);
+	// XXX use the right sequence here
+
+        uint8_t header_len;
+        uint8_t signature_len;
+        
+        if (msg->magic == MAVLINK_STX_MAVLINK1) {
+            header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN + 1;
+            signature_len = 0;
+            MAVLINK_START_UART_SEND(chan, header_len + msg->len + 2 + signature_len);
+            // we can't send the structure directly as it has extra mavlink2 elements in it
+            uint8_t buf[MAVLINK_CORE_HEADER_MAVLINK1_LEN + 1];
+            buf[0] = msg->magic;
+            buf[1] = msg->len;
+            buf[2] = msg->seq;
+            buf[3] = msg->sysid;
+            buf[4] = msg->compid;
+            buf[5] = msg->msgid & 0xFF;
+            _mavlink_send_uart(chan, (const char*)buf, header_len);
+        } else {
+            header_len = MAVLINK_CORE_HEADER_LEN + 1;
+            signature_len = (msg->incompat_flags & MAVLINK_IFLAG_SIGNED)?MAVLINK_SIGNATURE_BLOCK_LEN:0;
+            MAVLINK_START_UART_SEND(chan, header_len + msg->len + 2 + signature_len);
+            uint8_t buf[MAVLINK_CORE_HEADER_LEN + 1];
+            buf[0] = msg->magic;
+            buf[1] = msg->len;
+            buf[2] = msg->incompat_flags;
+            buf[3] = msg->compat_flags;
+            buf[4] = msg->seq;
+            buf[5] = msg->sysid;
+            buf[6] = msg->compid;
+            buf[7] = msg->msgid & 0xFF;
+            buf[8] = (msg->msgid >> 8) & 0xFF;
+            buf[9] = (msg->msgid >> 16) & 0xFF;
+            _mavlink_send_uart(chan, (const char *)buf, header_len);
+        }
+	_mavlink_send_uart(chan, _MAV_PAYLOAD(msg), msg->len);
+	_mavlink_send_uart(chan, (const char *)ck, 2);
+        if (signature_len != 0) {
+	    _mavlink_send_uart(chan, (const char *)msg->signature, MAVLINK_SIGNATURE_BLOCK_LEN);
+        }
+        MAVLINK_END_UART_SEND(chan, header_len + msg->len + 2 + signature_len);
+}
+#endif // MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+/**
+ * @brief Pack a message to send it over a serial byte stream
+ */
+MAVLINK_HELPER uint16_t mavlink_msg_to_send_buffer(uint8_t *buf, const mavlink_message_t *msg)
+{
+	uint8_t signature_len, header_len;
+	uint8_t *ck;
+        uint8_t length = msg->len;
+        
+	if (msg->magic == MAVLINK_STX_MAVLINK1) {
+		signature_len = 0;
+		header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN;
+		buf[0] = msg->magic;
+		buf[1] = length;
+		buf[2] = msg->seq;
+		buf[3] = msg->sysid;
+		buf[4] = msg->compid;
+		buf[5] = msg->msgid & 0xFF;
+		memcpy(&buf[6], _MAV_PAYLOAD(msg), msg->len);
+		ck = buf + header_len + 1 + (uint16_t)msg->len;
+	} else {
+		length = _mav_trim_payload(_MAV_PAYLOAD(msg), length);
+		header_len = MAVLINK_CORE_HEADER_LEN;
+		buf[0] = msg->magic;
+		buf[1] = length;
+		buf[2] = msg->incompat_flags;
+		buf[3] = msg->compat_flags;
+		buf[4] = msg->seq;
+		buf[5] = msg->sysid;
+		buf[6] = msg->compid;
+		buf[7] = msg->msgid & 0xFF;
+		buf[8] = (msg->msgid >> 8) & 0xFF;
+		buf[9] = (msg->msgid >> 16) & 0xFF;
+		memcpy(&buf[10], _MAV_PAYLOAD(msg), length);
+		ck = buf + header_len + 1 + (uint16_t)length;
+		signature_len = (msg->incompat_flags & MAVLINK_IFLAG_SIGNED)?MAVLINK_SIGNATURE_BLOCK_LEN:0;
+	}
+	ck[0] = (uint8_t)(msg->checksum & 0xFF);
+	ck[1] = (uint8_t)(msg->checksum >> 8);
+	if (signature_len > 0) {
+		memcpy(&ck[2], msg->signature, signature_len);
+	}
+
+	return header_len + 1 + 2 + (uint16_t)length + (uint16_t)signature_len;
+}
+
+union __mavlink_bitfield {
+	uint8_t uint8;
+	int8_t int8;
+	uint16_t uint16;
+	int16_t int16;
+	uint32_t uint32;
+	int32_t int32;
+};
+
+
+MAVLINK_HELPER void mavlink_start_checksum(mavlink_message_t* msg)
+{
+	uint16_t crcTmp = 0;
+	crc_init(&crcTmp);
+	msg->checksum = crcTmp;
+}
+
+MAVLINK_HELPER void mavlink_update_checksum(mavlink_message_t* msg, uint8_t c)
+{
+	uint16_t checksum = msg->checksum;
+	crc_accumulate(c, &checksum);
+	msg->checksum = checksum;
+}
+
+/*
+  return the crc_entry value for a msgid
+*/
+#ifndef MAVLINK_GET_MSG_ENTRY
+MAVLINK_HELPER const mavlink_msg_entry_t *mavlink_get_msg_entry(uint32_t msgid)
+{
+	static const mavlink_msg_entry_t mavlink_message_crcs[] = MAVLINK_MESSAGE_CRCS;
+        /*
+	  use a bisection search to find the right entry. A perfect hash may be better
+	  Note that this assumes the table is sorted by msgid
+	*/
+        uint32_t low=0, high=sizeof(mavlink_message_crcs)/sizeof(mavlink_message_crcs[0]) - 1;
+        while (low < high) {
+            uint32_t mid = (low+1+high)/2;
+            if (msgid < mavlink_message_crcs[mid].msgid) {
+                high = mid-1;
+                continue;
+            }
+            if (msgid > mavlink_message_crcs[mid].msgid) {
+                low = mid;
+                continue;
+            }
+            low = mid;
+            break;
+        }
+        if (mavlink_message_crcs[low].msgid != msgid) {
+            // msgid is not in the table
+            return NULL;
+        }
+        return &mavlink_message_crcs[low];
+}
+#endif // MAVLINK_GET_MSG_ENTRY
+
+/*
+  return the crc_extra value for a message
+*/
+MAVLINK_HELPER uint8_t mavlink_get_crc_extra(const mavlink_message_t *msg)
+{
+	const mavlink_msg_entry_t *e = mavlink_get_msg_entry(msg->msgid);
+	return e?e->crc_extra:0;
+}
+
+/*
+  return the min message length
+*/
+#define MAVLINK_HAVE_MIN_MESSAGE_LENGTH
+MAVLINK_HELPER uint8_t mavlink_min_message_length(const mavlink_message_t *msg)
+{
+	const mavlink_msg_entry_t *e = mavlink_get_msg_entry(msg->msgid);
+        return e?e->min_msg_len:0;
+}
+
+/*
+  return the max message length (including extensions)
+*/
+#define MAVLINK_HAVE_MAX_MESSAGE_LENGTH
+MAVLINK_HELPER uint8_t mavlink_max_message_length(const mavlink_message_t *msg)
+{
+	const mavlink_msg_entry_t *e = mavlink_get_msg_entry(msg->msgid);
+        return e?e->max_msg_len:0;
+}
+
+/**
+ * This is a variant of mavlink_frame_char() but with caller supplied
+ * parsing buffers. It is useful when you want to create a MAVLink
+ * parser in a library that doesn't use any global variables
+ *
+ * @param rxmsg    parsing message buffer
+ * @param status   parsing status buffer
+ * @param c        The char to parse
+ *
+ * @param r_message NULL if no message could be decoded, otherwise the message data
+ * @param r_mavlink_status if a message was decoded, this is filled with the channel's stats
+ * @return 0 if no message could be decoded, 1 on good message and CRC, 2 on bad CRC
+ *
+ */
+MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg, 
+                                                 mavlink_status_t* status,
+                                                 uint8_t c, 
+                                                 mavlink_message_t* r_message, 
+                                                 mavlink_status_t* r_mavlink_status)
+{
+
+	status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
+
+	switch (status->parse_state)
+	{
+	case MAVLINK_PARSE_STATE_UNINIT:
+	case MAVLINK_PARSE_STATE_IDLE:
+		if (c == MAVLINK_STX)
+		{
+			status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
+			rxmsg->len = 0;
+			rxmsg->magic = c;
+                        status->flags &= ~MAVLINK_STATUS_FLAG_IN_MAVLINK1;
+			mavlink_start_checksum(rxmsg);
+		} else if (c == MAVLINK_STX_MAVLINK1)
+		{
+			status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
+			rxmsg->len = 0;
+			rxmsg->magic = c;
+                        status->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
+			mavlink_start_checksum(rxmsg);
+		}
+		break;
+
+	case MAVLINK_PARSE_STATE_GOT_STX:
+			if (status->msg_received 
+/* Support shorter buffers than the
+   default maximum packet size */
+#if (MAVLINK_MAX_PAYLOAD_LEN < 255)
+				|| c > MAVLINK_MAX_PAYLOAD_LEN
+#endif
+				)
+		{
+			status->buffer_overrun++;
+			_mav_parse_error(status);
+			status->msg_received = 0;
+			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+		}
+		else
+		{
+			// NOT counting STX, LENGTH, SEQ, SYSID, COMPID, MSGID, CRC1 and CRC2
+			rxmsg->len = c;
+			status->packet_idx = 0;
+			mavlink_update_checksum(rxmsg, c);
+                        if (status->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) {
+                            rxmsg->incompat_flags = 0;
+                            rxmsg->compat_flags = 0;
+                            status->parse_state = MAVLINK_PARSE_STATE_GOT_COMPAT_FLAGS;
+                        } else {
+                            status->parse_state = MAVLINK_PARSE_STATE_GOT_LENGTH;
+                        }
+		}
+		break;
+
+	case MAVLINK_PARSE_STATE_GOT_LENGTH:
+		rxmsg->incompat_flags = c;
+		if ((rxmsg->incompat_flags & ~MAVLINK_IFLAG_MASK) != 0) {
+			// message includes an incompatible feature flag
+			_mav_parse_error(status);
+			status->msg_received = 0;
+			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+			break;
+		}
+		mavlink_update_checksum(rxmsg, c);
+		status->parse_state = MAVLINK_PARSE_STATE_GOT_INCOMPAT_FLAGS;
+		break;
+
+	case MAVLINK_PARSE_STATE_GOT_INCOMPAT_FLAGS:
+		rxmsg->compat_flags = c;
+		mavlink_update_checksum(rxmsg, c);
+		status->parse_state = MAVLINK_PARSE_STATE_GOT_COMPAT_FLAGS;
+		break;
+
+	case MAVLINK_PARSE_STATE_GOT_COMPAT_FLAGS:
+		rxmsg->seq = c;
+		mavlink_update_checksum(rxmsg, c);
+		status->parse_state = MAVLINK_PARSE_STATE_GOT_SEQ;
+		break;
+                
+	case MAVLINK_PARSE_STATE_GOT_SEQ:
+		rxmsg->sysid = c;
+		mavlink_update_checksum(rxmsg, c);
+		status->parse_state = MAVLINK_PARSE_STATE_GOT_SYSID;
+		break;
+
+	case MAVLINK_PARSE_STATE_GOT_SYSID:
+		rxmsg->compid = c;
+		mavlink_update_checksum(rxmsg, c);
+                status->parse_state = MAVLINK_PARSE_STATE_GOT_COMPID;
+		break;
+
+	case MAVLINK_PARSE_STATE_GOT_COMPID:
+		rxmsg->msgid = c;
+		mavlink_update_checksum(rxmsg, c);
+		if (status->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) {
+			if(rxmsg->len > 0) {
+				status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID3;
+			} else {
+				status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
+			}
+#ifdef MAVLINK_CHECK_MESSAGE_LENGTH
+			if (rxmsg->len < mavlink_min_message_length(rxmsg) ||
+				rxmsg->len > mavlink_max_message_length(rxmsg)) {
+				_mav_parse_error(status);
+				status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+				break;
+			}
+#endif
+		} else {
+			status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID1;
+		}
+		break;
+
+	case MAVLINK_PARSE_STATE_GOT_MSGID1:
+		rxmsg->msgid |= c<<8;
+		mavlink_update_checksum(rxmsg, c);
+		status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID2;
+		break;
+
+	case MAVLINK_PARSE_STATE_GOT_MSGID2:
+		rxmsg->msgid |= ((uint32_t)c)<<16;
+		mavlink_update_checksum(rxmsg, c);
+		if(rxmsg->len > 0){
+			status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID3;
+		} else {
+			status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
+		}
+#ifdef MAVLINK_CHECK_MESSAGE_LENGTH
+        if (rxmsg->len < mavlink_min_message_length(rxmsg) ||
+            rxmsg->len > mavlink_max_message_length(rxmsg))
+        {
+			_mav_parse_error(status);
+			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+			break;
+        }
+#endif
+		break;
+                
+	case MAVLINK_PARSE_STATE_GOT_MSGID3:
+		_MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx++] = (char)c;
+		mavlink_update_checksum(rxmsg, c);
+		if (status->packet_idx == rxmsg->len)
+		{
+			status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
+		}
+		break;
+
+	case MAVLINK_PARSE_STATE_GOT_PAYLOAD: {
+		const mavlink_msg_entry_t *e = mavlink_get_msg_entry(rxmsg->msgid);
+		uint8_t crc_extra = e?e->crc_extra:0;
+		mavlink_update_checksum(rxmsg, crc_extra);
+		if (c != (rxmsg->checksum & 0xFF)) {
+			status->parse_state = MAVLINK_PARSE_STATE_GOT_BAD_CRC1;
+		} else {
+			status->parse_state = MAVLINK_PARSE_STATE_GOT_CRC1;
+		}
+                rxmsg->ck[0] = c;
+
+		// zero-fill the packet to cope with short incoming packets
+                if (e && status->packet_idx < e->max_msg_len) {
+                        memset(&_MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx], 0, e->max_msg_len - status->packet_idx);
+		}
+		break;
+        }
+
+	case MAVLINK_PARSE_STATE_GOT_CRC1:
+	case MAVLINK_PARSE_STATE_GOT_BAD_CRC1:
+		if (status->parse_state == MAVLINK_PARSE_STATE_GOT_BAD_CRC1 || c != (rxmsg->checksum >> 8)) {
+			// got a bad CRC message
+			status->msg_received = MAVLINK_FRAMING_BAD_CRC;
+		} else {
+			// Successfully got message
+			status->msg_received = MAVLINK_FRAMING_OK;
+		}
+		rxmsg->ck[1] = c;
+
+		if (rxmsg->incompat_flags & MAVLINK_IFLAG_SIGNED) {
+			status->parse_state = MAVLINK_PARSE_STATE_SIGNATURE_WAIT;
+			status->signature_wait = MAVLINK_SIGNATURE_BLOCK_LEN;
+
+			// If the CRC is already wrong, don't overwrite msg_received,
+			// otherwise we can end up with garbage flagged as valid.
+			if (status->msg_received != MAVLINK_FRAMING_BAD_CRC) {
+				status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
+			}
+		} else {
+			if (status->signing &&
+			   	(status->signing->accept_unsigned_callback == NULL ||
+			   	 !status->signing->accept_unsigned_callback(status, rxmsg->msgid))) {
+
+				// If the CRC is already wrong, don't overwrite msg_received.
+				if (status->msg_received != MAVLINK_FRAMING_BAD_CRC) {
+					status->msg_received = MAVLINK_FRAMING_BAD_SIGNATURE;
+				}
+			}
+			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+			if (r_message != NULL) {
+				memcpy(r_message, rxmsg, sizeof(mavlink_message_t));
+			}
+		}
+		break;
+	case MAVLINK_PARSE_STATE_SIGNATURE_WAIT:
+		rxmsg->signature[MAVLINK_SIGNATURE_BLOCK_LEN-status->signature_wait] = c;
+		status->signature_wait--;
+		if (status->signature_wait == 0) {
+			// we have the whole signature, check it is OK
+#ifndef MAVLINK_NO_SIGNATURE_CHECK
+			bool sig_ok = mavlink_signature_check(status->signing, status->signing_streams, rxmsg);
+#else
+			bool sig_ok = true;
+#endif
+			if (!sig_ok &&
+			   	(status->signing->accept_unsigned_callback &&
+			   	 status->signing->accept_unsigned_callback(status, rxmsg->msgid))) {
+				// accepted via application level override
+				sig_ok = true;
+			}
+			if (sig_ok) {
+				status->msg_received = MAVLINK_FRAMING_OK;
+			} else {
+				status->msg_received = MAVLINK_FRAMING_BAD_SIGNATURE;
+			}
+			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+			if (r_message !=NULL) {
+				memcpy(r_message, rxmsg, sizeof(mavlink_message_t));
+			}
+		}
+		break;
+	}
+
+	// If a message has been successfully decoded, check index
+	if (status->msg_received == MAVLINK_FRAMING_OK)
+	{
+		//while(status->current_seq != rxmsg->seq)
+		//{
+		//	status->packet_rx_drop_count++;
+		//               status->current_seq++;
+		//}
+		status->current_rx_seq = rxmsg->seq;
+		// Initial condition: If no packet has been received so far, drop count is undefined
+		if (status->packet_rx_success_count == 0) status->packet_rx_drop_count = 0;
+		// Count this packet as received
+		status->packet_rx_success_count++;
+	}
+
+       if (r_message != NULL) {
+           r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
+       }
+       if (r_mavlink_status != NULL) {	
+           r_mavlink_status->parse_state = status->parse_state;
+           r_mavlink_status->packet_idx = status->packet_idx;
+           r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
+           r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
+           r_mavlink_status->packet_rx_drop_count = status->parse_error;
+           r_mavlink_status->flags = status->flags;
+       }
+       status->parse_error = 0;
+
+	if (status->msg_received == MAVLINK_FRAMING_BAD_CRC) {
+		/*
+		  the CRC came out wrong. We now need to overwrite the
+		  msg CRC with the one on the wire so that if the
+		  caller decides to forward the message anyway that
+		  mavlink_msg_to_send_buffer() won't overwrite the
+		  checksum
+		 */
+            if (r_message != NULL) {
+                r_message->checksum = rxmsg->ck[0] | (rxmsg->ck[1]<<8);
+            }
+	}
+
+	return status->msg_received;
+}
+
+/**
+ * This is a convenience function which handles the complete MAVLink parsing.
+ * the function will parse one byte at a time and return the complete packet once
+ * it could be successfully decoded. This function will return 0, 1 or
+ * 2 (MAVLINK_FRAMING_INCOMPLETE, MAVLINK_FRAMING_OK or MAVLINK_FRAMING_BAD_CRC)
+ *
+ * Messages are parsed into an internal buffer (one for each channel). When a complete
+ * message is received it is copies into *r_message and the channel's status is
+ * copied into *r_mavlink_status.
+ *
+ * @param chan     ID of the channel to be parsed.
+ *                 A channel is not a physical message channel like a serial port, but a logical partition of
+ *                 the communication streams. COMM_NB is the limit for the number of channels
+ *                 on MCU (e.g. ARM7), while COMM_NB_HIGH is the limit for the number of channels in Linux/Windows
+ * @param c        The char to parse
+ *
+ * @param r_message NULL if no message could be decoded, otherwise the message data
+ * @param r_mavlink_status if a message was decoded, this is filled with the channel's stats
+ * @return 0 if no message could be decoded, 1 on good message and CRC, 2 on bad CRC
+ *
+ * A typical use scenario of this function call is:
+ *
+ * @code
+ * #include <mavlink.h>
+ *
+ * mavlink_status_t status;
+ * mavlink_message_t msg;
+ * int chan = 0;
+ *
+ *
+ * while(serial.bytesAvailable > 0)
+ * {
+ *   uint8_t byte = serial.getNextByte();
+ *   if (mavlink_frame_char(chan, byte, &msg, &status) != MAVLINK_FRAMING_INCOMPLETE)
+ *     {
+ *     printf("Received message with ID %d, sequence: %d from component %d of system %d", msg.msgid, msg.seq, msg.compid, msg.sysid);
+ *     }
+ * }
+ *
+ *
+ * @endcode
+ */
+MAVLINK_HELPER uint8_t mavlink_frame_char(uint8_t chan, uint8_t c, mavlink_message_t* r_message, mavlink_status_t* r_mavlink_status)
+{
+	return mavlink_frame_char_buffer(mavlink_get_channel_buffer(chan),
+					 mavlink_get_channel_status(chan),
+					 c,
+					 r_message,
+					 r_mavlink_status);
+}
+
+/**
+ * Set the protocol version
+ */
+MAVLINK_HELPER void mavlink_set_proto_version(uint8_t chan, unsigned int version)
+{
+	mavlink_status_t *status = mavlink_get_channel_status(chan);
+	if (version > 1) {
+		status->flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
+	} else {
+		status->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+	}
+}
+
+/**
+ * Get the protocol version
+ *
+ * @return 1 for v1, 2 for v2
+ */
+MAVLINK_HELPER unsigned int mavlink_get_proto_version(uint8_t chan)
+{
+	mavlink_status_t *status = mavlink_get_channel_status(chan);
+	if ((status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) > 0) {
+		return 1;
+	} else {
+		return 2;
+	}
+}
+
+/**
+ * This is a convenience function which handles the complete MAVLink parsing.
+ * the function will parse one byte at a time and return the complete packet once
+ * it could be successfully decoded. This function will return 0 or 1.
+ *
+ * Messages are parsed into an internal buffer (one for each channel). When a complete
+ * message is received it is copies into *r_message and the channel's status is
+ * copied into *r_mavlink_status.
+ *
+ * @param chan     ID of the channel to be parsed.
+ *                 A channel is not a physical message channel like a serial port, but a logical partition of
+ *                 the communication streams. COMM_NB is the limit for the number of channels
+ *                 on MCU (e.g. ARM7), while COMM_NB_HIGH is the limit for the number of channels in Linux/Windows
+ * @param c        The char to parse
+ *
+ * @param r_message NULL if no message could be decoded, otherwise the message data
+ * @param r_mavlink_status if a message was decoded, this is filled with the channel's stats
+ * @return 0 if no message could be decoded or bad CRC, 1 on good message and CRC
+ *
+ * A typical use scenario of this function call is:
+ *
+ * @code
+ * #include <mavlink.h>
+ *
+ * mavlink_status_t status;
+ * mavlink_message_t msg;
+ * int chan = 0;
+ *
+ *
+ * while(serial.bytesAvailable > 0)
+ * {
+ *   uint8_t byte = serial.getNextByte();
+ *   if (mavlink_parse_char(chan, byte, &msg, &status))
+ *     {
+ *     printf("Received message with ID %d, sequence: %d from component %d of system %d", msg.msgid, msg.seq, msg.compid, msg.sysid);
+ *     }
+ * }
+ *
+ *
+ * @endcode
+ */
+MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_message_t* r_message, mavlink_status_t* r_mavlink_status)
+{
+    uint8_t msg_received = mavlink_frame_char(chan, c, r_message, r_mavlink_status);
+    if (msg_received == MAVLINK_FRAMING_BAD_CRC ||
+	msg_received == MAVLINK_FRAMING_BAD_SIGNATURE) {
+	    // we got a bad CRC. Treat as a parse failure
+	    mavlink_message_t* rxmsg = mavlink_get_channel_buffer(chan);
+	    mavlink_status_t* status = mavlink_get_channel_status(chan);
+	    _mav_parse_error(status);
+	    status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
+	    status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+	    if (c == MAVLINK_STX)
+	    {
+		    status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
+		    rxmsg->len = 0;
+		    mavlink_start_checksum(rxmsg);
+	    }
+	    return 0;
+    }
+    return msg_received;
+}
+
+/**
+ * @brief Put a bitfield of length 1-32 bit into the buffer
+ *
+ * @param b the value to add, will be encoded in the bitfield
+ * @param bits number of bits to use to encode b, e.g. 1 for boolean, 2, 3, etc.
+ * @param packet_index the position in the packet (the index of the first byte to use)
+ * @param bit_index the position in the byte (the index of the first bit to use)
+ * @param buffer packet buffer to write into
+ * @return new position of the last used byte in the buffer
+ */
+MAVLINK_HELPER uint8_t put_bitfield_n_by_index(int32_t b, uint8_t bits, uint8_t packet_index, uint8_t bit_index, uint8_t* r_bit_index, uint8_t* buffer)
+{
+	uint16_t bits_remain = bits;
+	// Transform number into network order
+	int32_t v;
+	uint8_t i_bit_index, i_byte_index, curr_bits_n;
+#if MAVLINK_NEED_BYTE_SWAP
+	union {
+		int32_t i;
+		uint8_t b[4];
+	} bin, bout;
+	bin.i = b;
+	bout.b[0] = bin.b[3];
+	bout.b[1] = bin.b[2];
+	bout.b[2] = bin.b[1];
+	bout.b[3] = bin.b[0];
+	v = bout.i;
+#else
+	v = b;
+#endif
+
+	// buffer in
+	// 01100000 01000000 00000000 11110001
+	// buffer out
+	// 11110001 00000000 01000000 01100000
+
+	// Existing partly filled byte (four free slots)
+	// 0111xxxx
+
+	// Mask n free bits
+	// 00001111 = 2^0 + 2^1 + 2^2 + 2^3 = 2^n - 1
+	// = ((uint32_t)(1 << n)) - 1; // = 2^n - 1
+
+	// Shift n bits into the right position
+	// out = in >> n;
+
+	// Mask and shift bytes
+	i_bit_index = bit_index;
+	i_byte_index = packet_index;
+	if (bit_index > 0)
+	{
+		// If bits were available at start, they were available
+		// in the byte before the current index
+		i_byte_index--;
+	}
+
+	// While bits have not been packed yet
+	while (bits_remain > 0)
+	{
+		// Bits still have to be packed
+		// there can be more than 8 bits, so
+		// we might have to pack them into more than one byte
+
+		// First pack everything we can into the current 'open' byte
+		//curr_bits_n = bits_remain << 3; // Equals  bits_remain mod 8
+		//FIXME
+		if (bits_remain <= (uint8_t)(8 - i_bit_index))
+		{
+			// Enough space
+			curr_bits_n = (uint8_t)bits_remain;
+		}
+		else
+		{
+			curr_bits_n = (8 - i_bit_index);
+		}
+		
+		// Pack these n bits into the current byte
+		// Mask out whatever was at that position with ones (xxx11111)
+		buffer[i_byte_index] &= (0xFF >> (8 - curr_bits_n));
+		// Put content to this position, by masking out the non-used part
+		buffer[i_byte_index] |= ((0x00 << curr_bits_n) & v);
+		
+		// Increment the bit index
+		i_bit_index += curr_bits_n;
+
+		// Now proceed to the next byte, if necessary
+		bits_remain -= curr_bits_n;
+		if (bits_remain > 0)
+		{
+			// Offer another 8 bits / one byte
+			i_byte_index++;
+			i_bit_index = 0;
+		}
+	}
+	
+	*r_bit_index = i_bit_index;
+	// If a partly filled byte is present, mark this as consumed
+	if (i_bit_index != 7) i_byte_index++;
+	return i_byte_index - packet_index;
+}
+
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+// To make MAVLink work on your MCU, define comm_send_ch() if you wish
+// to send 1 byte at a time, or MAVLINK_SEND_UART_BYTES() to send a
+// whole packet at a time
+
+/*
+
+#include "mavlink_types.h"
+
+void comm_send_ch(mavlink_channel_t chan, uint8_t ch)
+{
+    if (chan == MAVLINK_COMM_0)
+    {
+        uart0_transmit(ch);
+    }
+    if (chan == MAVLINK_COMM_1)
+    {
+    	uart1_transmit(ch);
+    }
+}
+ */
+
+MAVLINK_HELPER void _mavlink_send_uart(mavlink_channel_t chan, const char *buf, uint16_t len)
+{
+#ifdef MAVLINK_SEND_UART_BYTES
+	/* this is the more efficient approach, if the platform
+	   defines it */
+	MAVLINK_SEND_UART_BYTES(chan, (const uint8_t *)buf, len);
+#else
+	/* fallback to one byte at a time */
+	uint16_t i;
+	for (i = 0; i < len; i++) {
+		comm_send_ch(chan, (uint8_t)buf[i]);
+	}
+#endif
+}
+#endif // MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+#ifdef MAVLINK_USE_CXX_NAMESPACE
+} // namespace mavlink
+#endif

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_airspeed.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_airspeed.h
@@ -1,0 +1,372 @@
+#pragma once
+// MESSAGE AIRSPEED PACKING
+
+#define MAVLINK_MSG_ID_AIRSPEED 295
+
+
+typedef struct __mavlink_airspeed_t {
+ float airspeed; /*< [m/s] Calibrated airspeed (CAS).*/
+ float raw_press; /*< [hPa] Raw differential pressure. NaN for value unknown/not supplied.*/
+ int16_t temperature; /*< [cdegC] Temperature. INT16_MAX for value unknown/not supplied.*/
+ uint8_t id; /*<  Sensor ID.*/
+ uint8_t flags; /*<  Airspeed sensor flags.*/
+} mavlink_airspeed_t;
+
+#define MAVLINK_MSG_ID_AIRSPEED_LEN 12
+#define MAVLINK_MSG_ID_AIRSPEED_MIN_LEN 12
+#define MAVLINK_MSG_ID_295_LEN 12
+#define MAVLINK_MSG_ID_295_MIN_LEN 12
+
+#define MAVLINK_MSG_ID_AIRSPEED_CRC 234
+#define MAVLINK_MSG_ID_295_CRC 234
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_AIRSPEED { \
+    295, \
+    "AIRSPEED", \
+    5, \
+    {  { "id", NULL, MAVLINK_TYPE_UINT8_T, 0, 10, offsetof(mavlink_airspeed_t, id) }, \
+         { "airspeed", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_airspeed_t, airspeed) }, \
+         { "temperature", NULL, MAVLINK_TYPE_INT16_T, 0, 8, offsetof(mavlink_airspeed_t, temperature) }, \
+         { "raw_press", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_airspeed_t, raw_press) }, \
+         { "flags", NULL, MAVLINK_TYPE_UINT8_T, 0, 11, offsetof(mavlink_airspeed_t, flags) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_AIRSPEED { \
+    "AIRSPEED", \
+    5, \
+    {  { "id", NULL, MAVLINK_TYPE_UINT8_T, 0, 10, offsetof(mavlink_airspeed_t, id) }, \
+         { "airspeed", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_airspeed_t, airspeed) }, \
+         { "temperature", NULL, MAVLINK_TYPE_INT16_T, 0, 8, offsetof(mavlink_airspeed_t, temperature) }, \
+         { "raw_press", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_airspeed_t, raw_press) }, \
+         { "flags", NULL, MAVLINK_TYPE_UINT8_T, 0, 11, offsetof(mavlink_airspeed_t, flags) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a airspeed message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param id  Sensor ID.
+ * @param airspeed [m/s] Calibrated airspeed (CAS).
+ * @param temperature [cdegC] Temperature. INT16_MAX for value unknown/not supplied.
+ * @param raw_press [hPa] Raw differential pressure. NaN for value unknown/not supplied.
+ * @param flags  Airspeed sensor flags.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_airspeed_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint8_t id, float airspeed, int16_t temperature, float raw_press, uint8_t flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_AIRSPEED_LEN];
+    _mav_put_float(buf, 0, airspeed);
+    _mav_put_float(buf, 4, raw_press);
+    _mav_put_int16_t(buf, 8, temperature);
+    _mav_put_uint8_t(buf, 10, id);
+    _mav_put_uint8_t(buf, 11, flags);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_AIRSPEED_LEN);
+#else
+    mavlink_airspeed_t packet;
+    packet.airspeed = airspeed;
+    packet.raw_press = raw_press;
+    packet.temperature = temperature;
+    packet.id = id;
+    packet.flags = flags;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_AIRSPEED_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_AIRSPEED;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_AIRSPEED_MIN_LEN, MAVLINK_MSG_ID_AIRSPEED_LEN, MAVLINK_MSG_ID_AIRSPEED_CRC);
+}
+
+/**
+ * @brief Pack a airspeed message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param id  Sensor ID.
+ * @param airspeed [m/s] Calibrated airspeed (CAS).
+ * @param temperature [cdegC] Temperature. INT16_MAX for value unknown/not supplied.
+ * @param raw_press [hPa] Raw differential pressure. NaN for value unknown/not supplied.
+ * @param flags  Airspeed sensor flags.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_airspeed_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint8_t id, float airspeed, int16_t temperature, float raw_press, uint8_t flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_AIRSPEED_LEN];
+    _mav_put_float(buf, 0, airspeed);
+    _mav_put_float(buf, 4, raw_press);
+    _mav_put_int16_t(buf, 8, temperature);
+    _mav_put_uint8_t(buf, 10, id);
+    _mav_put_uint8_t(buf, 11, flags);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_AIRSPEED_LEN);
+#else
+    mavlink_airspeed_t packet;
+    packet.airspeed = airspeed;
+    packet.raw_press = raw_press;
+    packet.temperature = temperature;
+    packet.id = id;
+    packet.flags = flags;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_AIRSPEED_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_AIRSPEED;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_AIRSPEED_MIN_LEN, MAVLINK_MSG_ID_AIRSPEED_LEN, MAVLINK_MSG_ID_AIRSPEED_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_AIRSPEED_MIN_LEN, MAVLINK_MSG_ID_AIRSPEED_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a airspeed message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param id  Sensor ID.
+ * @param airspeed [m/s] Calibrated airspeed (CAS).
+ * @param temperature [cdegC] Temperature. INT16_MAX for value unknown/not supplied.
+ * @param raw_press [hPa] Raw differential pressure. NaN for value unknown/not supplied.
+ * @param flags  Airspeed sensor flags.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_airspeed_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint8_t id,float airspeed,int16_t temperature,float raw_press,uint8_t flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_AIRSPEED_LEN];
+    _mav_put_float(buf, 0, airspeed);
+    _mav_put_float(buf, 4, raw_press);
+    _mav_put_int16_t(buf, 8, temperature);
+    _mav_put_uint8_t(buf, 10, id);
+    _mav_put_uint8_t(buf, 11, flags);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_AIRSPEED_LEN);
+#else
+    mavlink_airspeed_t packet;
+    packet.airspeed = airspeed;
+    packet.raw_press = raw_press;
+    packet.temperature = temperature;
+    packet.id = id;
+    packet.flags = flags;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_AIRSPEED_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_AIRSPEED;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_AIRSPEED_MIN_LEN, MAVLINK_MSG_ID_AIRSPEED_LEN, MAVLINK_MSG_ID_AIRSPEED_CRC);
+}
+
+/**
+ * @brief Encode a airspeed struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param airspeed C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_airspeed_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_airspeed_t* airspeed)
+{
+    return mavlink_msg_airspeed_pack(system_id, component_id, msg, airspeed->id, airspeed->airspeed, airspeed->temperature, airspeed->raw_press, airspeed->flags);
+}
+
+/**
+ * @brief Encode a airspeed struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param airspeed C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_airspeed_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_airspeed_t* airspeed)
+{
+    return mavlink_msg_airspeed_pack_chan(system_id, component_id, chan, msg, airspeed->id, airspeed->airspeed, airspeed->temperature, airspeed->raw_press, airspeed->flags);
+}
+
+/**
+ * @brief Encode a airspeed struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param airspeed C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_airspeed_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_airspeed_t* airspeed)
+{
+    return mavlink_msg_airspeed_pack_status(system_id, component_id, _status, msg,  airspeed->id, airspeed->airspeed, airspeed->temperature, airspeed->raw_press, airspeed->flags);
+}
+
+/**
+ * @brief Send a airspeed message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param id  Sensor ID.
+ * @param airspeed [m/s] Calibrated airspeed (CAS).
+ * @param temperature [cdegC] Temperature. INT16_MAX for value unknown/not supplied.
+ * @param raw_press [hPa] Raw differential pressure. NaN for value unknown/not supplied.
+ * @param flags  Airspeed sensor flags.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_airspeed_send(mavlink_channel_t chan, uint8_t id, float airspeed, int16_t temperature, float raw_press, uint8_t flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_AIRSPEED_LEN];
+    _mav_put_float(buf, 0, airspeed);
+    _mav_put_float(buf, 4, raw_press);
+    _mav_put_int16_t(buf, 8, temperature);
+    _mav_put_uint8_t(buf, 10, id);
+    _mav_put_uint8_t(buf, 11, flags);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AIRSPEED, buf, MAVLINK_MSG_ID_AIRSPEED_MIN_LEN, MAVLINK_MSG_ID_AIRSPEED_LEN, MAVLINK_MSG_ID_AIRSPEED_CRC);
+#else
+    mavlink_airspeed_t packet;
+    packet.airspeed = airspeed;
+    packet.raw_press = raw_press;
+    packet.temperature = temperature;
+    packet.id = id;
+    packet.flags = flags;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AIRSPEED, (const char *)&packet, MAVLINK_MSG_ID_AIRSPEED_MIN_LEN, MAVLINK_MSG_ID_AIRSPEED_LEN, MAVLINK_MSG_ID_AIRSPEED_CRC);
+#endif
+}
+
+/**
+ * @brief Send a airspeed message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_airspeed_send_struct(mavlink_channel_t chan, const mavlink_airspeed_t* airspeed)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_airspeed_send(chan, airspeed->id, airspeed->airspeed, airspeed->temperature, airspeed->raw_press, airspeed->flags);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AIRSPEED, (const char *)airspeed, MAVLINK_MSG_ID_AIRSPEED_MIN_LEN, MAVLINK_MSG_ID_AIRSPEED_LEN, MAVLINK_MSG_ID_AIRSPEED_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_AIRSPEED_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_airspeed_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint8_t id, float airspeed, int16_t temperature, float raw_press, uint8_t flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_float(buf, 0, airspeed);
+    _mav_put_float(buf, 4, raw_press);
+    _mav_put_int16_t(buf, 8, temperature);
+    _mav_put_uint8_t(buf, 10, id);
+    _mav_put_uint8_t(buf, 11, flags);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AIRSPEED, buf, MAVLINK_MSG_ID_AIRSPEED_MIN_LEN, MAVLINK_MSG_ID_AIRSPEED_LEN, MAVLINK_MSG_ID_AIRSPEED_CRC);
+#else
+    mavlink_airspeed_t *packet = (mavlink_airspeed_t *)msgbuf;
+    packet->airspeed = airspeed;
+    packet->raw_press = raw_press;
+    packet->temperature = temperature;
+    packet->id = id;
+    packet->flags = flags;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AIRSPEED, (const char *)packet, MAVLINK_MSG_ID_AIRSPEED_MIN_LEN, MAVLINK_MSG_ID_AIRSPEED_LEN, MAVLINK_MSG_ID_AIRSPEED_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE AIRSPEED UNPACKING
+
+
+/**
+ * @brief Get field id from airspeed message
+ *
+ * @return  Sensor ID.
+ */
+static inline uint8_t mavlink_msg_airspeed_get_id(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  10);
+}
+
+/**
+ * @brief Get field airspeed from airspeed message
+ *
+ * @return [m/s] Calibrated airspeed (CAS).
+ */
+static inline float mavlink_msg_airspeed_get_airspeed(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  0);
+}
+
+/**
+ * @brief Get field temperature from airspeed message
+ *
+ * @return [cdegC] Temperature. INT16_MAX for value unknown/not supplied.
+ */
+static inline int16_t mavlink_msg_airspeed_get_temperature(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int16_t(msg,  8);
+}
+
+/**
+ * @brief Get field raw_press from airspeed message
+ *
+ * @return [hPa] Raw differential pressure. NaN for value unknown/not supplied.
+ */
+static inline float mavlink_msg_airspeed_get_raw_press(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  4);
+}
+
+/**
+ * @brief Get field flags from airspeed message
+ *
+ * @return  Airspeed sensor flags.
+ */
+static inline uint8_t mavlink_msg_airspeed_get_flags(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  11);
+}
+
+/**
+ * @brief Decode a airspeed message into a struct
+ *
+ * @param msg The message to decode
+ * @param airspeed C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_airspeed_decode(const mavlink_message_t* msg, mavlink_airspeed_t* airspeed)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    airspeed->airspeed = mavlink_msg_airspeed_get_airspeed(msg);
+    airspeed->raw_press = mavlink_msg_airspeed_get_raw_press(msg);
+    airspeed->temperature = mavlink_msg_airspeed_get_temperature(msg);
+    airspeed->id = mavlink_msg_airspeed_get_id(msg);
+    airspeed->flags = mavlink_msg_airspeed_get_flags(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_AIRSPEED_LEN? msg->len : MAVLINK_MSG_ID_AIRSPEED_LEN;
+        memset(airspeed, 0, MAVLINK_MSG_ID_AIRSPEED_LEN);
+    memcpy(airspeed, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_available_modes.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_available_modes.h
@@ -1,0 +1,390 @@
+#pragma once
+// MESSAGE AVAILABLE_MODES PACKING
+
+#define MAVLINK_MSG_ID_AVAILABLE_MODES 435
+
+
+typedef struct __mavlink_available_modes_t {
+ uint32_t custom_mode; /*<  A bitfield for use for autopilot-specific flags*/
+ uint32_t properties; /*<  Mode properties.*/
+ uint8_t number_modes; /*<  The total number of available modes for the current vehicle type.*/
+ uint8_t mode_index; /*<  The current mode index within number_modes, indexed from 1.*/
+ uint8_t standard_mode; /*<  Standard mode.*/
+ char mode_name[35]; /*<  Name of custom mode, with null termination character. Should be omitted for standard modes.*/
+} mavlink_available_modes_t;
+
+#define MAVLINK_MSG_ID_AVAILABLE_MODES_LEN 46
+#define MAVLINK_MSG_ID_AVAILABLE_MODES_MIN_LEN 46
+#define MAVLINK_MSG_ID_435_LEN 46
+#define MAVLINK_MSG_ID_435_MIN_LEN 46
+
+#define MAVLINK_MSG_ID_AVAILABLE_MODES_CRC 134
+#define MAVLINK_MSG_ID_435_CRC 134
+
+#define MAVLINK_MSG_AVAILABLE_MODES_FIELD_MODE_NAME_LEN 35
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_AVAILABLE_MODES { \
+    435, \
+    "AVAILABLE_MODES", \
+    6, \
+    {  { "number_modes", NULL, MAVLINK_TYPE_UINT8_T, 0, 8, offsetof(mavlink_available_modes_t, number_modes) }, \
+         { "mode_index", NULL, MAVLINK_TYPE_UINT8_T, 0, 9, offsetof(mavlink_available_modes_t, mode_index) }, \
+         { "standard_mode", NULL, MAVLINK_TYPE_UINT8_T, 0, 10, offsetof(mavlink_available_modes_t, standard_mode) }, \
+         { "custom_mode", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_available_modes_t, custom_mode) }, \
+         { "properties", NULL, MAVLINK_TYPE_UINT32_T, 0, 4, offsetof(mavlink_available_modes_t, properties) }, \
+         { "mode_name", NULL, MAVLINK_TYPE_CHAR, 35, 11, offsetof(mavlink_available_modes_t, mode_name) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_AVAILABLE_MODES { \
+    "AVAILABLE_MODES", \
+    6, \
+    {  { "number_modes", NULL, MAVLINK_TYPE_UINT8_T, 0, 8, offsetof(mavlink_available_modes_t, number_modes) }, \
+         { "mode_index", NULL, MAVLINK_TYPE_UINT8_T, 0, 9, offsetof(mavlink_available_modes_t, mode_index) }, \
+         { "standard_mode", NULL, MAVLINK_TYPE_UINT8_T, 0, 10, offsetof(mavlink_available_modes_t, standard_mode) }, \
+         { "custom_mode", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_available_modes_t, custom_mode) }, \
+         { "properties", NULL, MAVLINK_TYPE_UINT32_T, 0, 4, offsetof(mavlink_available_modes_t, properties) }, \
+         { "mode_name", NULL, MAVLINK_TYPE_CHAR, 35, 11, offsetof(mavlink_available_modes_t, mode_name) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a available_modes message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param number_modes  The total number of available modes for the current vehicle type.
+ * @param mode_index  The current mode index within number_modes, indexed from 1.
+ * @param standard_mode  Standard mode.
+ * @param custom_mode  A bitfield for use for autopilot-specific flags
+ * @param properties  Mode properties.
+ * @param mode_name  Name of custom mode, with null termination character. Should be omitted for standard modes.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_available_modes_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint8_t number_modes, uint8_t mode_index, uint8_t standard_mode, uint32_t custom_mode, uint32_t properties, const char *mode_name)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_AVAILABLE_MODES_LEN];
+    _mav_put_uint32_t(buf, 0, custom_mode);
+    _mav_put_uint32_t(buf, 4, properties);
+    _mav_put_uint8_t(buf, 8, number_modes);
+    _mav_put_uint8_t(buf, 9, mode_index);
+    _mav_put_uint8_t(buf, 10, standard_mode);
+    _mav_put_char_array(buf, 11, mode_name, 35);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN);
+#else
+    mavlink_available_modes_t packet;
+    packet.custom_mode = custom_mode;
+    packet.properties = properties;
+    packet.number_modes = number_modes;
+    packet.mode_index = mode_index;
+    packet.standard_mode = standard_mode;
+    mav_array_memcpy(packet.mode_name, mode_name, sizeof(char)*35);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_AVAILABLE_MODES;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_AVAILABLE_MODES_MIN_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_CRC);
+}
+
+/**
+ * @brief Pack a available_modes message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param number_modes  The total number of available modes for the current vehicle type.
+ * @param mode_index  The current mode index within number_modes, indexed from 1.
+ * @param standard_mode  Standard mode.
+ * @param custom_mode  A bitfield for use for autopilot-specific flags
+ * @param properties  Mode properties.
+ * @param mode_name  Name of custom mode, with null termination character. Should be omitted for standard modes.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_available_modes_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint8_t number_modes, uint8_t mode_index, uint8_t standard_mode, uint32_t custom_mode, uint32_t properties, const char *mode_name)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_AVAILABLE_MODES_LEN];
+    _mav_put_uint32_t(buf, 0, custom_mode);
+    _mav_put_uint32_t(buf, 4, properties);
+    _mav_put_uint8_t(buf, 8, number_modes);
+    _mav_put_uint8_t(buf, 9, mode_index);
+    _mav_put_uint8_t(buf, 10, standard_mode);
+    _mav_put_char_array(buf, 11, mode_name, 35);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN);
+#else
+    mavlink_available_modes_t packet;
+    packet.custom_mode = custom_mode;
+    packet.properties = properties;
+    packet.number_modes = number_modes;
+    packet.mode_index = mode_index;
+    packet.standard_mode = standard_mode;
+    mav_array_memcpy(packet.mode_name, mode_name, sizeof(char)*35);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_AVAILABLE_MODES;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_AVAILABLE_MODES_MIN_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_AVAILABLE_MODES_MIN_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a available_modes message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param number_modes  The total number of available modes for the current vehicle type.
+ * @param mode_index  The current mode index within number_modes, indexed from 1.
+ * @param standard_mode  Standard mode.
+ * @param custom_mode  A bitfield for use for autopilot-specific flags
+ * @param properties  Mode properties.
+ * @param mode_name  Name of custom mode, with null termination character. Should be omitted for standard modes.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_available_modes_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint8_t number_modes,uint8_t mode_index,uint8_t standard_mode,uint32_t custom_mode,uint32_t properties,const char *mode_name)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_AVAILABLE_MODES_LEN];
+    _mav_put_uint32_t(buf, 0, custom_mode);
+    _mav_put_uint32_t(buf, 4, properties);
+    _mav_put_uint8_t(buf, 8, number_modes);
+    _mav_put_uint8_t(buf, 9, mode_index);
+    _mav_put_uint8_t(buf, 10, standard_mode);
+    _mav_put_char_array(buf, 11, mode_name, 35);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN);
+#else
+    mavlink_available_modes_t packet;
+    packet.custom_mode = custom_mode;
+    packet.properties = properties;
+    packet.number_modes = number_modes;
+    packet.mode_index = mode_index;
+    packet.standard_mode = standard_mode;
+    mav_array_memcpy(packet.mode_name, mode_name, sizeof(char)*35);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_AVAILABLE_MODES;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_AVAILABLE_MODES_MIN_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_CRC);
+}
+
+/**
+ * @brief Encode a available_modes struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param available_modes C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_available_modes_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_available_modes_t* available_modes)
+{
+    return mavlink_msg_available_modes_pack(system_id, component_id, msg, available_modes->number_modes, available_modes->mode_index, available_modes->standard_mode, available_modes->custom_mode, available_modes->properties, available_modes->mode_name);
+}
+
+/**
+ * @brief Encode a available_modes struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param available_modes C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_available_modes_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_available_modes_t* available_modes)
+{
+    return mavlink_msg_available_modes_pack_chan(system_id, component_id, chan, msg, available_modes->number_modes, available_modes->mode_index, available_modes->standard_mode, available_modes->custom_mode, available_modes->properties, available_modes->mode_name);
+}
+
+/**
+ * @brief Encode a available_modes struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param available_modes C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_available_modes_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_available_modes_t* available_modes)
+{
+    return mavlink_msg_available_modes_pack_status(system_id, component_id, _status, msg,  available_modes->number_modes, available_modes->mode_index, available_modes->standard_mode, available_modes->custom_mode, available_modes->properties, available_modes->mode_name);
+}
+
+/**
+ * @brief Send a available_modes message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param number_modes  The total number of available modes for the current vehicle type.
+ * @param mode_index  The current mode index within number_modes, indexed from 1.
+ * @param standard_mode  Standard mode.
+ * @param custom_mode  A bitfield for use for autopilot-specific flags
+ * @param properties  Mode properties.
+ * @param mode_name  Name of custom mode, with null termination character. Should be omitted for standard modes.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_available_modes_send(mavlink_channel_t chan, uint8_t number_modes, uint8_t mode_index, uint8_t standard_mode, uint32_t custom_mode, uint32_t properties, const char *mode_name)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_AVAILABLE_MODES_LEN];
+    _mav_put_uint32_t(buf, 0, custom_mode);
+    _mav_put_uint32_t(buf, 4, properties);
+    _mav_put_uint8_t(buf, 8, number_modes);
+    _mav_put_uint8_t(buf, 9, mode_index);
+    _mav_put_uint8_t(buf, 10, standard_mode);
+    _mav_put_char_array(buf, 11, mode_name, 35);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AVAILABLE_MODES, buf, MAVLINK_MSG_ID_AVAILABLE_MODES_MIN_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_CRC);
+#else
+    mavlink_available_modes_t packet;
+    packet.custom_mode = custom_mode;
+    packet.properties = properties;
+    packet.number_modes = number_modes;
+    packet.mode_index = mode_index;
+    packet.standard_mode = standard_mode;
+    mav_array_memcpy(packet.mode_name, mode_name, sizeof(char)*35);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AVAILABLE_MODES, (const char *)&packet, MAVLINK_MSG_ID_AVAILABLE_MODES_MIN_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_CRC);
+#endif
+}
+
+/**
+ * @brief Send a available_modes message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_available_modes_send_struct(mavlink_channel_t chan, const mavlink_available_modes_t* available_modes)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_available_modes_send(chan, available_modes->number_modes, available_modes->mode_index, available_modes->standard_mode, available_modes->custom_mode, available_modes->properties, available_modes->mode_name);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AVAILABLE_MODES, (const char *)available_modes, MAVLINK_MSG_ID_AVAILABLE_MODES_MIN_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_AVAILABLE_MODES_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_available_modes_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint8_t number_modes, uint8_t mode_index, uint8_t standard_mode, uint32_t custom_mode, uint32_t properties, const char *mode_name)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint32_t(buf, 0, custom_mode);
+    _mav_put_uint32_t(buf, 4, properties);
+    _mav_put_uint8_t(buf, 8, number_modes);
+    _mav_put_uint8_t(buf, 9, mode_index);
+    _mav_put_uint8_t(buf, 10, standard_mode);
+    _mav_put_char_array(buf, 11, mode_name, 35);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AVAILABLE_MODES, buf, MAVLINK_MSG_ID_AVAILABLE_MODES_MIN_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_CRC);
+#else
+    mavlink_available_modes_t *packet = (mavlink_available_modes_t *)msgbuf;
+    packet->custom_mode = custom_mode;
+    packet->properties = properties;
+    packet->number_modes = number_modes;
+    packet->mode_index = mode_index;
+    packet->standard_mode = standard_mode;
+    mav_array_memcpy(packet->mode_name, mode_name, sizeof(char)*35);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_AVAILABLE_MODES, (const char *)packet, MAVLINK_MSG_ID_AVAILABLE_MODES_MIN_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN, MAVLINK_MSG_ID_AVAILABLE_MODES_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE AVAILABLE_MODES UNPACKING
+
+
+/**
+ * @brief Get field number_modes from available_modes message
+ *
+ * @return  The total number of available modes for the current vehicle type.
+ */
+static inline uint8_t mavlink_msg_available_modes_get_number_modes(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  8);
+}
+
+/**
+ * @brief Get field mode_index from available_modes message
+ *
+ * @return  The current mode index within number_modes, indexed from 1.
+ */
+static inline uint8_t mavlink_msg_available_modes_get_mode_index(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  9);
+}
+
+/**
+ * @brief Get field standard_mode from available_modes message
+ *
+ * @return  Standard mode.
+ */
+static inline uint8_t mavlink_msg_available_modes_get_standard_mode(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  10);
+}
+
+/**
+ * @brief Get field custom_mode from available_modes message
+ *
+ * @return  A bitfield for use for autopilot-specific flags
+ */
+static inline uint32_t mavlink_msg_available_modes_get_custom_mode(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  0);
+}
+
+/**
+ * @brief Get field properties from available_modes message
+ *
+ * @return  Mode properties.
+ */
+static inline uint32_t mavlink_msg_available_modes_get_properties(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  4);
+}
+
+/**
+ * @brief Get field mode_name from available_modes message
+ *
+ * @return  Name of custom mode, with null termination character. Should be omitted for standard modes.
+ */
+static inline uint16_t mavlink_msg_available_modes_get_mode_name(const mavlink_message_t* msg, char *mode_name)
+{
+    return _MAV_RETURN_char_array(msg, mode_name, 35,  11);
+}
+
+/**
+ * @brief Decode a available_modes message into a struct
+ *
+ * @param msg The message to decode
+ * @param available_modes C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_available_modes_decode(const mavlink_message_t* msg, mavlink_available_modes_t* available_modes)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    available_modes->custom_mode = mavlink_msg_available_modes_get_custom_mode(msg);
+    available_modes->properties = mavlink_msg_available_modes_get_properties(msg);
+    available_modes->number_modes = mavlink_msg_available_modes_get_number_modes(msg);
+    available_modes->mode_index = mavlink_msg_available_modes_get_mode_index(msg);
+    available_modes->standard_mode = mavlink_msg_available_modes_get_standard_mode(msg);
+    mavlink_msg_available_modes_get_mode_name(msg, available_modes->mode_name);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_AVAILABLE_MODES_LEN? msg->len : MAVLINK_MSG_ID_AVAILABLE_MODES_LEN;
+        memset(available_modes, 0, MAVLINK_MSG_ID_AVAILABLE_MODES_LEN);
+    memcpy(available_modes, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_battery_status_v2.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_battery_status_v2.h
@@ -1,0 +1,456 @@
+#pragma once
+// MESSAGE BATTERY_STATUS_V2 PACKING
+
+#define MAVLINK_MSG_ID_BATTERY_STATUS_V2 369
+
+
+typedef struct __mavlink_battery_status_v2_t {
+ float voltage; /*< [V] Battery voltage (total). NaN: field not provided.*/
+ float current; /*< [A] Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.*/
+ float capacity_consumed; /*< [Ah] Consumed charge. NaN: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.*/
+ float capacity_remaining; /*< [Ah] Remaining charge (until empty). UINT32_MAX: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.*/
+ uint32_t status_flags; /*<  Fault, health, readiness, and other status indications.*/
+ int16_t temperature; /*< [cdegC] Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.*/
+ uint8_t id; /*<  Battery ID*/
+ uint8_t percent_remaining; /*< [%] Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.*/
+} mavlink_battery_status_v2_t;
+
+#define MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN 24
+#define MAVLINK_MSG_ID_BATTERY_STATUS_V2_MIN_LEN 24
+#define MAVLINK_MSG_ID_369_LEN 24
+#define MAVLINK_MSG_ID_369_MIN_LEN 24
+
+#define MAVLINK_MSG_ID_BATTERY_STATUS_V2_CRC 151
+#define MAVLINK_MSG_ID_369_CRC 151
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_BATTERY_STATUS_V2 { \
+    369, \
+    "BATTERY_STATUS_V2", \
+    8, \
+    {  { "id", NULL, MAVLINK_TYPE_UINT8_T, 0, 22, offsetof(mavlink_battery_status_v2_t, id) }, \
+         { "temperature", NULL, MAVLINK_TYPE_INT16_T, 0, 20, offsetof(mavlink_battery_status_v2_t, temperature) }, \
+         { "voltage", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_battery_status_v2_t, voltage) }, \
+         { "current", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_battery_status_v2_t, current) }, \
+         { "capacity_consumed", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_battery_status_v2_t, capacity_consumed) }, \
+         { "capacity_remaining", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_battery_status_v2_t, capacity_remaining) }, \
+         { "percent_remaining", NULL, MAVLINK_TYPE_UINT8_T, 0, 23, offsetof(mavlink_battery_status_v2_t, percent_remaining) }, \
+         { "status_flags", NULL, MAVLINK_TYPE_UINT32_T, 0, 16, offsetof(mavlink_battery_status_v2_t, status_flags) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_BATTERY_STATUS_V2 { \
+    "BATTERY_STATUS_V2", \
+    8, \
+    {  { "id", NULL, MAVLINK_TYPE_UINT8_T, 0, 22, offsetof(mavlink_battery_status_v2_t, id) }, \
+         { "temperature", NULL, MAVLINK_TYPE_INT16_T, 0, 20, offsetof(mavlink_battery_status_v2_t, temperature) }, \
+         { "voltage", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_battery_status_v2_t, voltage) }, \
+         { "current", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_battery_status_v2_t, current) }, \
+         { "capacity_consumed", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_battery_status_v2_t, capacity_consumed) }, \
+         { "capacity_remaining", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_battery_status_v2_t, capacity_remaining) }, \
+         { "percent_remaining", NULL, MAVLINK_TYPE_UINT8_T, 0, 23, offsetof(mavlink_battery_status_v2_t, percent_remaining) }, \
+         { "status_flags", NULL, MAVLINK_TYPE_UINT32_T, 0, 16, offsetof(mavlink_battery_status_v2_t, status_flags) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a battery_status_v2 message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param id  Battery ID
+ * @param temperature [cdegC] Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.
+ * @param voltage [V] Battery voltage (total). NaN: field not provided.
+ * @param current [A] Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.
+ * @param capacity_consumed [Ah] Consumed charge. NaN: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.
+ * @param capacity_remaining [Ah] Remaining charge (until empty). UINT32_MAX: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.
+ * @param percent_remaining [%] Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.
+ * @param status_flags  Fault, health, readiness, and other status indications.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_battery_status_v2_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint8_t id, int16_t temperature, float voltage, float current, float capacity_consumed, float capacity_remaining, uint8_t percent_remaining, uint32_t status_flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN];
+    _mav_put_float(buf, 0, voltage);
+    _mav_put_float(buf, 4, current);
+    _mav_put_float(buf, 8, capacity_consumed);
+    _mav_put_float(buf, 12, capacity_remaining);
+    _mav_put_uint32_t(buf, 16, status_flags);
+    _mav_put_int16_t(buf, 20, temperature);
+    _mav_put_uint8_t(buf, 22, id);
+    _mav_put_uint8_t(buf, 23, percent_remaining);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN);
+#else
+    mavlink_battery_status_v2_t packet;
+    packet.voltage = voltage;
+    packet.current = current;
+    packet.capacity_consumed = capacity_consumed;
+    packet.capacity_remaining = capacity_remaining;
+    packet.status_flags = status_flags;
+    packet.temperature = temperature;
+    packet.id = id;
+    packet.percent_remaining = percent_remaining;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_BATTERY_STATUS_V2;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_BATTERY_STATUS_V2_MIN_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_CRC);
+}
+
+/**
+ * @brief Pack a battery_status_v2 message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param id  Battery ID
+ * @param temperature [cdegC] Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.
+ * @param voltage [V] Battery voltage (total). NaN: field not provided.
+ * @param current [A] Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.
+ * @param capacity_consumed [Ah] Consumed charge. NaN: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.
+ * @param capacity_remaining [Ah] Remaining charge (until empty). UINT32_MAX: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.
+ * @param percent_remaining [%] Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.
+ * @param status_flags  Fault, health, readiness, and other status indications.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_battery_status_v2_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint8_t id, int16_t temperature, float voltage, float current, float capacity_consumed, float capacity_remaining, uint8_t percent_remaining, uint32_t status_flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN];
+    _mav_put_float(buf, 0, voltage);
+    _mav_put_float(buf, 4, current);
+    _mav_put_float(buf, 8, capacity_consumed);
+    _mav_put_float(buf, 12, capacity_remaining);
+    _mav_put_uint32_t(buf, 16, status_flags);
+    _mav_put_int16_t(buf, 20, temperature);
+    _mav_put_uint8_t(buf, 22, id);
+    _mav_put_uint8_t(buf, 23, percent_remaining);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN);
+#else
+    mavlink_battery_status_v2_t packet;
+    packet.voltage = voltage;
+    packet.current = current;
+    packet.capacity_consumed = capacity_consumed;
+    packet.capacity_remaining = capacity_remaining;
+    packet.status_flags = status_flags;
+    packet.temperature = temperature;
+    packet.id = id;
+    packet.percent_remaining = percent_remaining;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_BATTERY_STATUS_V2;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_BATTERY_STATUS_V2_MIN_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_BATTERY_STATUS_V2_MIN_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a battery_status_v2 message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param id  Battery ID
+ * @param temperature [cdegC] Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.
+ * @param voltage [V] Battery voltage (total). NaN: field not provided.
+ * @param current [A] Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.
+ * @param capacity_consumed [Ah] Consumed charge. NaN: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.
+ * @param capacity_remaining [Ah] Remaining charge (until empty). UINT32_MAX: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.
+ * @param percent_remaining [%] Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.
+ * @param status_flags  Fault, health, readiness, and other status indications.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_battery_status_v2_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint8_t id,int16_t temperature,float voltage,float current,float capacity_consumed,float capacity_remaining,uint8_t percent_remaining,uint32_t status_flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN];
+    _mav_put_float(buf, 0, voltage);
+    _mav_put_float(buf, 4, current);
+    _mav_put_float(buf, 8, capacity_consumed);
+    _mav_put_float(buf, 12, capacity_remaining);
+    _mav_put_uint32_t(buf, 16, status_flags);
+    _mav_put_int16_t(buf, 20, temperature);
+    _mav_put_uint8_t(buf, 22, id);
+    _mav_put_uint8_t(buf, 23, percent_remaining);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN);
+#else
+    mavlink_battery_status_v2_t packet;
+    packet.voltage = voltage;
+    packet.current = current;
+    packet.capacity_consumed = capacity_consumed;
+    packet.capacity_remaining = capacity_remaining;
+    packet.status_flags = status_flags;
+    packet.temperature = temperature;
+    packet.id = id;
+    packet.percent_remaining = percent_remaining;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_BATTERY_STATUS_V2;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_BATTERY_STATUS_V2_MIN_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_CRC);
+}
+
+/**
+ * @brief Encode a battery_status_v2 struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param battery_status_v2 C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_battery_status_v2_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_battery_status_v2_t* battery_status_v2)
+{
+    return mavlink_msg_battery_status_v2_pack(system_id, component_id, msg, battery_status_v2->id, battery_status_v2->temperature, battery_status_v2->voltage, battery_status_v2->current, battery_status_v2->capacity_consumed, battery_status_v2->capacity_remaining, battery_status_v2->percent_remaining, battery_status_v2->status_flags);
+}
+
+/**
+ * @brief Encode a battery_status_v2 struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param battery_status_v2 C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_battery_status_v2_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_battery_status_v2_t* battery_status_v2)
+{
+    return mavlink_msg_battery_status_v2_pack_chan(system_id, component_id, chan, msg, battery_status_v2->id, battery_status_v2->temperature, battery_status_v2->voltage, battery_status_v2->current, battery_status_v2->capacity_consumed, battery_status_v2->capacity_remaining, battery_status_v2->percent_remaining, battery_status_v2->status_flags);
+}
+
+/**
+ * @brief Encode a battery_status_v2 struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param battery_status_v2 C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_battery_status_v2_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_battery_status_v2_t* battery_status_v2)
+{
+    return mavlink_msg_battery_status_v2_pack_status(system_id, component_id, _status, msg,  battery_status_v2->id, battery_status_v2->temperature, battery_status_v2->voltage, battery_status_v2->current, battery_status_v2->capacity_consumed, battery_status_v2->capacity_remaining, battery_status_v2->percent_remaining, battery_status_v2->status_flags);
+}
+
+/**
+ * @brief Send a battery_status_v2 message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param id  Battery ID
+ * @param temperature [cdegC] Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.
+ * @param voltage [V] Battery voltage (total). NaN: field not provided.
+ * @param current [A] Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.
+ * @param capacity_consumed [Ah] Consumed charge. NaN: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.
+ * @param capacity_remaining [Ah] Remaining charge (until empty). UINT32_MAX: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.
+ * @param percent_remaining [%] Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.
+ * @param status_flags  Fault, health, readiness, and other status indications.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_battery_status_v2_send(mavlink_channel_t chan, uint8_t id, int16_t temperature, float voltage, float current, float capacity_consumed, float capacity_remaining, uint8_t percent_remaining, uint32_t status_flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN];
+    _mav_put_float(buf, 0, voltage);
+    _mav_put_float(buf, 4, current);
+    _mav_put_float(buf, 8, capacity_consumed);
+    _mav_put_float(buf, 12, capacity_remaining);
+    _mav_put_uint32_t(buf, 16, status_flags);
+    _mav_put_int16_t(buf, 20, temperature);
+    _mav_put_uint8_t(buf, 22, id);
+    _mav_put_uint8_t(buf, 23, percent_remaining);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_BATTERY_STATUS_V2, buf, MAVLINK_MSG_ID_BATTERY_STATUS_V2_MIN_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_CRC);
+#else
+    mavlink_battery_status_v2_t packet;
+    packet.voltage = voltage;
+    packet.current = current;
+    packet.capacity_consumed = capacity_consumed;
+    packet.capacity_remaining = capacity_remaining;
+    packet.status_flags = status_flags;
+    packet.temperature = temperature;
+    packet.id = id;
+    packet.percent_remaining = percent_remaining;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_BATTERY_STATUS_V2, (const char *)&packet, MAVLINK_MSG_ID_BATTERY_STATUS_V2_MIN_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_CRC);
+#endif
+}
+
+/**
+ * @brief Send a battery_status_v2 message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_battery_status_v2_send_struct(mavlink_channel_t chan, const mavlink_battery_status_v2_t* battery_status_v2)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_battery_status_v2_send(chan, battery_status_v2->id, battery_status_v2->temperature, battery_status_v2->voltage, battery_status_v2->current, battery_status_v2->capacity_consumed, battery_status_v2->capacity_remaining, battery_status_v2->percent_remaining, battery_status_v2->status_flags);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_BATTERY_STATUS_V2, (const char *)battery_status_v2, MAVLINK_MSG_ID_BATTERY_STATUS_V2_MIN_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_battery_status_v2_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint8_t id, int16_t temperature, float voltage, float current, float capacity_consumed, float capacity_remaining, uint8_t percent_remaining, uint32_t status_flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_float(buf, 0, voltage);
+    _mav_put_float(buf, 4, current);
+    _mav_put_float(buf, 8, capacity_consumed);
+    _mav_put_float(buf, 12, capacity_remaining);
+    _mav_put_uint32_t(buf, 16, status_flags);
+    _mav_put_int16_t(buf, 20, temperature);
+    _mav_put_uint8_t(buf, 22, id);
+    _mav_put_uint8_t(buf, 23, percent_remaining);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_BATTERY_STATUS_V2, buf, MAVLINK_MSG_ID_BATTERY_STATUS_V2_MIN_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_CRC);
+#else
+    mavlink_battery_status_v2_t *packet = (mavlink_battery_status_v2_t *)msgbuf;
+    packet->voltage = voltage;
+    packet->current = current;
+    packet->capacity_consumed = capacity_consumed;
+    packet->capacity_remaining = capacity_remaining;
+    packet->status_flags = status_flags;
+    packet->temperature = temperature;
+    packet->id = id;
+    packet->percent_remaining = percent_remaining;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_BATTERY_STATUS_V2, (const char *)packet, MAVLINK_MSG_ID_BATTERY_STATUS_V2_MIN_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN, MAVLINK_MSG_ID_BATTERY_STATUS_V2_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE BATTERY_STATUS_V2 UNPACKING
+
+
+/**
+ * @brief Get field id from battery_status_v2 message
+ *
+ * @return  Battery ID
+ */
+static inline uint8_t mavlink_msg_battery_status_v2_get_id(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  22);
+}
+
+/**
+ * @brief Get field temperature from battery_status_v2 message
+ *
+ * @return [cdegC] Temperature of the whole battery pack (not internal electronics). INT16_MAX field not provided.
+ */
+static inline int16_t mavlink_msg_battery_status_v2_get_temperature(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int16_t(msg,  20);
+}
+
+/**
+ * @brief Get field voltage from battery_status_v2 message
+ *
+ * @return [V] Battery voltage (total). NaN: field not provided.
+ */
+static inline float mavlink_msg_battery_status_v2_get_voltage(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  0);
+}
+
+/**
+ * @brief Get field current from battery_status_v2 message
+ *
+ * @return [A] Battery current (through all cells/loads). Positive value when discharging and negative if charging. NaN: field not provided.
+ */
+static inline float mavlink_msg_battery_status_v2_get_current(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  4);
+}
+
+/**
+ * @brief Get field capacity_consumed from battery_status_v2 message
+ *
+ * @return [Ah] Consumed charge. NaN: field not provided. This is either the consumption since power-on or since the battery was full, depending on the value of MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL.
+ */
+static inline float mavlink_msg_battery_status_v2_get_capacity_consumed(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  8);
+}
+
+/**
+ * @brief Get field capacity_remaining from battery_status_v2 message
+ *
+ * @return [Ah] Remaining charge (until empty). UINT32_MAX: field not provided. Note: If MAV_BATTERY_STATUS_FLAGS_CAPACITY_RELATIVE_TO_FULL is unset, this value is based on the assumption the battery was full when the system was powered.
+ */
+static inline float mavlink_msg_battery_status_v2_get_capacity_remaining(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  12);
+}
+
+/**
+ * @brief Get field percent_remaining from battery_status_v2 message
+ *
+ * @return [%] Remaining battery energy. Values: [0-100], UINT8_MAX: field not provided.
+ */
+static inline uint8_t mavlink_msg_battery_status_v2_get_percent_remaining(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  23);
+}
+
+/**
+ * @brief Get field status_flags from battery_status_v2 message
+ *
+ * @return  Fault, health, readiness, and other status indications.
+ */
+static inline uint32_t mavlink_msg_battery_status_v2_get_status_flags(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  16);
+}
+
+/**
+ * @brief Decode a battery_status_v2 message into a struct
+ *
+ * @param msg The message to decode
+ * @param battery_status_v2 C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_battery_status_v2_decode(const mavlink_message_t* msg, mavlink_battery_status_v2_t* battery_status_v2)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    battery_status_v2->voltage = mavlink_msg_battery_status_v2_get_voltage(msg);
+    battery_status_v2->current = mavlink_msg_battery_status_v2_get_current(msg);
+    battery_status_v2->capacity_consumed = mavlink_msg_battery_status_v2_get_capacity_consumed(msg);
+    battery_status_v2->capacity_remaining = mavlink_msg_battery_status_v2_get_capacity_remaining(msg);
+    battery_status_v2->status_flags = mavlink_msg_battery_status_v2_get_status_flags(msg);
+    battery_status_v2->temperature = mavlink_msg_battery_status_v2_get_temperature(msg);
+    battery_status_v2->id = mavlink_msg_battery_status_v2_get_id(msg);
+    battery_status_v2->percent_remaining = mavlink_msg_battery_status_v2_get_percent_remaining(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN? msg->len : MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN;
+        memset(battery_status_v2, 0, MAVLINK_MSG_ID_BATTERY_STATUS_V2_LEN);
+    memcpy(battery_status_v2, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_component_information_basic.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_component_information_basic.h
@@ -1,0 +1,422 @@
+#pragma once
+// MESSAGE COMPONENT_INFORMATION_BASIC PACKING
+
+#define MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC 396
+
+
+typedef struct __mavlink_component_information_basic_t {
+ uint64_t capabilities; /*<  Component capability flags*/
+ uint32_t time_boot_ms; /*< [ms] Timestamp (time since system boot).*/
+ char vendor_name[32]; /*<  Name of the component vendor. Needs to be zero terminated. The field is optional and can be empty/all zeros.*/
+ char model_name[32]; /*<  Name of the component model. Needs to be zero terminated. The field is optional and can be empty/all zeros.*/
+ char software_version[24]; /*<  Software version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.*/
+ char hardware_version[24]; /*<  Hardware version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.*/
+ char serial_number[32]; /*<  Hardware serial number. The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.*/
+} mavlink_component_information_basic_t;
+
+#define MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN 156
+#define MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_MIN_LEN 156
+#define MAVLINK_MSG_ID_396_LEN 156
+#define MAVLINK_MSG_ID_396_MIN_LEN 156
+
+#define MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_CRC 129
+#define MAVLINK_MSG_ID_396_CRC 129
+
+#define MAVLINK_MSG_COMPONENT_INFORMATION_BASIC_FIELD_VENDOR_NAME_LEN 32
+#define MAVLINK_MSG_COMPONENT_INFORMATION_BASIC_FIELD_MODEL_NAME_LEN 32
+#define MAVLINK_MSG_COMPONENT_INFORMATION_BASIC_FIELD_SOFTWARE_VERSION_LEN 24
+#define MAVLINK_MSG_COMPONENT_INFORMATION_BASIC_FIELD_HARDWARE_VERSION_LEN 24
+#define MAVLINK_MSG_COMPONENT_INFORMATION_BASIC_FIELD_SERIAL_NUMBER_LEN 32
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_COMPONENT_INFORMATION_BASIC { \
+    396, \
+    "COMPONENT_INFORMATION_BASIC", \
+    7, \
+    {  { "time_boot_ms", NULL, MAVLINK_TYPE_UINT32_T, 0, 8, offsetof(mavlink_component_information_basic_t, time_boot_ms) }, \
+         { "capabilities", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_component_information_basic_t, capabilities) }, \
+         { "vendor_name", NULL, MAVLINK_TYPE_CHAR, 32, 12, offsetof(mavlink_component_information_basic_t, vendor_name) }, \
+         { "model_name", NULL, MAVLINK_TYPE_CHAR, 32, 44, offsetof(mavlink_component_information_basic_t, model_name) }, \
+         { "software_version", NULL, MAVLINK_TYPE_CHAR, 24, 76, offsetof(mavlink_component_information_basic_t, software_version) }, \
+         { "hardware_version", NULL, MAVLINK_TYPE_CHAR, 24, 100, offsetof(mavlink_component_information_basic_t, hardware_version) }, \
+         { "serial_number", NULL, MAVLINK_TYPE_CHAR, 32, 124, offsetof(mavlink_component_information_basic_t, serial_number) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_COMPONENT_INFORMATION_BASIC { \
+    "COMPONENT_INFORMATION_BASIC", \
+    7, \
+    {  { "time_boot_ms", NULL, MAVLINK_TYPE_UINT32_T, 0, 8, offsetof(mavlink_component_information_basic_t, time_boot_ms) }, \
+         { "capabilities", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_component_information_basic_t, capabilities) }, \
+         { "vendor_name", NULL, MAVLINK_TYPE_CHAR, 32, 12, offsetof(mavlink_component_information_basic_t, vendor_name) }, \
+         { "model_name", NULL, MAVLINK_TYPE_CHAR, 32, 44, offsetof(mavlink_component_information_basic_t, model_name) }, \
+         { "software_version", NULL, MAVLINK_TYPE_CHAR, 24, 76, offsetof(mavlink_component_information_basic_t, software_version) }, \
+         { "hardware_version", NULL, MAVLINK_TYPE_CHAR, 24, 100, offsetof(mavlink_component_information_basic_t, hardware_version) }, \
+         { "serial_number", NULL, MAVLINK_TYPE_CHAR, 32, 124, offsetof(mavlink_component_information_basic_t, serial_number) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a component_information_basic message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param capabilities  Component capability flags
+ * @param vendor_name  Name of the component vendor. Needs to be zero terminated. The field is optional and can be empty/all zeros.
+ * @param model_name  Name of the component model. Needs to be zero terminated. The field is optional and can be empty/all zeros.
+ * @param software_version  Software version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @param hardware_version  Hardware version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @param serial_number  Hardware serial number. The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_component_information_basic_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint32_t time_boot_ms, uint64_t capabilities, const char *vendor_name, const char *model_name, const char *software_version, const char *hardware_version, const char *serial_number)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN];
+    _mav_put_uint64_t(buf, 0, capabilities);
+    _mav_put_uint32_t(buf, 8, time_boot_ms);
+    _mav_put_char_array(buf, 12, vendor_name, 32);
+    _mav_put_char_array(buf, 44, model_name, 32);
+    _mav_put_char_array(buf, 76, software_version, 24);
+    _mav_put_char_array(buf, 100, hardware_version, 24);
+    _mav_put_char_array(buf, 124, serial_number, 32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN);
+#else
+    mavlink_component_information_basic_t packet;
+    packet.capabilities = capabilities;
+    packet.time_boot_ms = time_boot_ms;
+    mav_array_memcpy(packet.vendor_name, vendor_name, sizeof(char)*32);
+    mav_array_memcpy(packet.model_name, model_name, sizeof(char)*32);
+    mav_array_memcpy(packet.software_version, software_version, sizeof(char)*24);
+    mav_array_memcpy(packet.hardware_version, hardware_version, sizeof(char)*24);
+    mav_array_memcpy(packet.serial_number, serial_number, sizeof(char)*32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_MIN_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_CRC);
+}
+
+/**
+ * @brief Pack a component_information_basic message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param capabilities  Component capability flags
+ * @param vendor_name  Name of the component vendor. Needs to be zero terminated. The field is optional and can be empty/all zeros.
+ * @param model_name  Name of the component model. Needs to be zero terminated. The field is optional and can be empty/all zeros.
+ * @param software_version  Software version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @param hardware_version  Hardware version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @param serial_number  Hardware serial number. The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_component_information_basic_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint32_t time_boot_ms, uint64_t capabilities, const char *vendor_name, const char *model_name, const char *software_version, const char *hardware_version, const char *serial_number)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN];
+    _mav_put_uint64_t(buf, 0, capabilities);
+    _mav_put_uint32_t(buf, 8, time_boot_ms);
+    _mav_put_char_array(buf, 12, vendor_name, 32);
+    _mav_put_char_array(buf, 44, model_name, 32);
+    _mav_put_char_array(buf, 76, software_version, 24);
+    _mav_put_char_array(buf, 100, hardware_version, 24);
+    _mav_put_char_array(buf, 124, serial_number, 32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN);
+#else
+    mavlink_component_information_basic_t packet;
+    packet.capabilities = capabilities;
+    packet.time_boot_ms = time_boot_ms;
+    mav_array_memcpy(packet.vendor_name, vendor_name, sizeof(char)*32);
+    mav_array_memcpy(packet.model_name, model_name, sizeof(char)*32);
+    mav_array_memcpy(packet.software_version, software_version, sizeof(char)*24);
+    mav_array_memcpy(packet.hardware_version, hardware_version, sizeof(char)*24);
+    mav_array_memcpy(packet.serial_number, serial_number, sizeof(char)*32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_MIN_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_MIN_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a component_information_basic message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param capabilities  Component capability flags
+ * @param vendor_name  Name of the component vendor. Needs to be zero terminated. The field is optional and can be empty/all zeros.
+ * @param model_name  Name of the component model. Needs to be zero terminated. The field is optional and can be empty/all zeros.
+ * @param software_version  Software version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @param hardware_version  Hardware version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @param serial_number  Hardware serial number. The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_component_information_basic_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint32_t time_boot_ms,uint64_t capabilities,const char *vendor_name,const char *model_name,const char *software_version,const char *hardware_version,const char *serial_number)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN];
+    _mav_put_uint64_t(buf, 0, capabilities);
+    _mav_put_uint32_t(buf, 8, time_boot_ms);
+    _mav_put_char_array(buf, 12, vendor_name, 32);
+    _mav_put_char_array(buf, 44, model_name, 32);
+    _mav_put_char_array(buf, 76, software_version, 24);
+    _mav_put_char_array(buf, 100, hardware_version, 24);
+    _mav_put_char_array(buf, 124, serial_number, 32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN);
+#else
+    mavlink_component_information_basic_t packet;
+    packet.capabilities = capabilities;
+    packet.time_boot_ms = time_boot_ms;
+    mav_array_memcpy(packet.vendor_name, vendor_name, sizeof(char)*32);
+    mav_array_memcpy(packet.model_name, model_name, sizeof(char)*32);
+    mav_array_memcpy(packet.software_version, software_version, sizeof(char)*24);
+    mav_array_memcpy(packet.hardware_version, hardware_version, sizeof(char)*24);
+    mav_array_memcpy(packet.serial_number, serial_number, sizeof(char)*32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_MIN_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_CRC);
+}
+
+/**
+ * @brief Encode a component_information_basic struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param component_information_basic C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_component_information_basic_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_component_information_basic_t* component_information_basic)
+{
+    return mavlink_msg_component_information_basic_pack(system_id, component_id, msg, component_information_basic->time_boot_ms, component_information_basic->capabilities, component_information_basic->vendor_name, component_information_basic->model_name, component_information_basic->software_version, component_information_basic->hardware_version, component_information_basic->serial_number);
+}
+
+/**
+ * @brief Encode a component_information_basic struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param component_information_basic C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_component_information_basic_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_component_information_basic_t* component_information_basic)
+{
+    return mavlink_msg_component_information_basic_pack_chan(system_id, component_id, chan, msg, component_information_basic->time_boot_ms, component_information_basic->capabilities, component_information_basic->vendor_name, component_information_basic->model_name, component_information_basic->software_version, component_information_basic->hardware_version, component_information_basic->serial_number);
+}
+
+/**
+ * @brief Encode a component_information_basic struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param component_information_basic C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_component_information_basic_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_component_information_basic_t* component_information_basic)
+{
+    return mavlink_msg_component_information_basic_pack_status(system_id, component_id, _status, msg,  component_information_basic->time_boot_ms, component_information_basic->capabilities, component_information_basic->vendor_name, component_information_basic->model_name, component_information_basic->software_version, component_information_basic->hardware_version, component_information_basic->serial_number);
+}
+
+/**
+ * @brief Send a component_information_basic message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param capabilities  Component capability flags
+ * @param vendor_name  Name of the component vendor. Needs to be zero terminated. The field is optional and can be empty/all zeros.
+ * @param model_name  Name of the component model. Needs to be zero terminated. The field is optional and can be empty/all zeros.
+ * @param software_version  Software version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @param hardware_version  Hardware version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ * @param serial_number  Hardware serial number. The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_component_information_basic_send(mavlink_channel_t chan, uint32_t time_boot_ms, uint64_t capabilities, const char *vendor_name, const char *model_name, const char *software_version, const char *hardware_version, const char *serial_number)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN];
+    _mav_put_uint64_t(buf, 0, capabilities);
+    _mav_put_uint32_t(buf, 8, time_boot_ms);
+    _mav_put_char_array(buf, 12, vendor_name, 32);
+    _mav_put_char_array(buf, 44, model_name, 32);
+    _mav_put_char_array(buf, 76, software_version, 24);
+    _mav_put_char_array(buf, 100, hardware_version, 24);
+    _mav_put_char_array(buf, 124, serial_number, 32);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC, buf, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_MIN_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_CRC);
+#else
+    mavlink_component_information_basic_t packet;
+    packet.capabilities = capabilities;
+    packet.time_boot_ms = time_boot_ms;
+    mav_array_memcpy(packet.vendor_name, vendor_name, sizeof(char)*32);
+    mav_array_memcpy(packet.model_name, model_name, sizeof(char)*32);
+    mav_array_memcpy(packet.software_version, software_version, sizeof(char)*24);
+    mav_array_memcpy(packet.hardware_version, hardware_version, sizeof(char)*24);
+    mav_array_memcpy(packet.serial_number, serial_number, sizeof(char)*32);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC, (const char *)&packet, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_MIN_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_CRC);
+#endif
+}
+
+/**
+ * @brief Send a component_information_basic message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_component_information_basic_send_struct(mavlink_channel_t chan, const mavlink_component_information_basic_t* component_information_basic)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_component_information_basic_send(chan, component_information_basic->time_boot_ms, component_information_basic->capabilities, component_information_basic->vendor_name, component_information_basic->model_name, component_information_basic->software_version, component_information_basic->hardware_version, component_information_basic->serial_number);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC, (const char *)component_information_basic, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_MIN_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_component_information_basic_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint32_t time_boot_ms, uint64_t capabilities, const char *vendor_name, const char *model_name, const char *software_version, const char *hardware_version, const char *serial_number)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint64_t(buf, 0, capabilities);
+    _mav_put_uint32_t(buf, 8, time_boot_ms);
+    _mav_put_char_array(buf, 12, vendor_name, 32);
+    _mav_put_char_array(buf, 44, model_name, 32);
+    _mav_put_char_array(buf, 76, software_version, 24);
+    _mav_put_char_array(buf, 100, hardware_version, 24);
+    _mav_put_char_array(buf, 124, serial_number, 32);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC, buf, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_MIN_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_CRC);
+#else
+    mavlink_component_information_basic_t *packet = (mavlink_component_information_basic_t *)msgbuf;
+    packet->capabilities = capabilities;
+    packet->time_boot_ms = time_boot_ms;
+    mav_array_memcpy(packet->vendor_name, vendor_name, sizeof(char)*32);
+    mav_array_memcpy(packet->model_name, model_name, sizeof(char)*32);
+    mav_array_memcpy(packet->software_version, software_version, sizeof(char)*24);
+    mav_array_memcpy(packet->hardware_version, hardware_version, sizeof(char)*24);
+    mav_array_memcpy(packet->serial_number, serial_number, sizeof(char)*32);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC, (const char *)packet, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_MIN_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE COMPONENT_INFORMATION_BASIC UNPACKING
+
+
+/**
+ * @brief Get field time_boot_ms from component_information_basic message
+ *
+ * @return [ms] Timestamp (time since system boot).
+ */
+static inline uint32_t mavlink_msg_component_information_basic_get_time_boot_ms(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  8);
+}
+
+/**
+ * @brief Get field capabilities from component_information_basic message
+ *
+ * @return  Component capability flags
+ */
+static inline uint64_t mavlink_msg_component_information_basic_get_capabilities(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint64_t(msg,  0);
+}
+
+/**
+ * @brief Get field vendor_name from component_information_basic message
+ *
+ * @return  Name of the component vendor. Needs to be zero terminated. The field is optional and can be empty/all zeros.
+ */
+static inline uint16_t mavlink_msg_component_information_basic_get_vendor_name(const mavlink_message_t* msg, char *vendor_name)
+{
+    return _MAV_RETURN_char_array(msg, vendor_name, 32,  12);
+}
+
+/**
+ * @brief Get field model_name from component_information_basic message
+ *
+ * @return  Name of the component model. Needs to be zero terminated. The field is optional and can be empty/all zeros.
+ */
+static inline uint16_t mavlink_msg_component_information_basic_get_model_name(const mavlink_message_t* msg, char *model_name)
+{
+    return _MAV_RETURN_char_array(msg, model_name, 32,  44);
+}
+
+/**
+ * @brief Get field software_version from component_information_basic message
+ *
+ * @return  Software version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ */
+static inline uint16_t mavlink_msg_component_information_basic_get_software_version(const mavlink_message_t* msg, char *software_version)
+{
+    return _MAV_RETURN_char_array(msg, software_version, 24,  76);
+}
+
+/**
+ * @brief Get field hardware_version from component_information_basic message
+ *
+ * @return  Hardware version. The recommended format is SEMVER: 'major.minor.patch'  (any format may be used). The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ */
+static inline uint16_t mavlink_msg_component_information_basic_get_hardware_version(const mavlink_message_t* msg, char *hardware_version)
+{
+    return _MAV_RETURN_char_array(msg, hardware_version, 24,  100);
+}
+
+/**
+ * @brief Get field serial_number from component_information_basic message
+ *
+ * @return  Hardware serial number. The field must be zero terminated if it has a value. The field is optional and can be empty/all zeros.
+ */
+static inline uint16_t mavlink_msg_component_information_basic_get_serial_number(const mavlink_message_t* msg, char *serial_number)
+{
+    return _MAV_RETURN_char_array(msg, serial_number, 32,  124);
+}
+
+/**
+ * @brief Decode a component_information_basic message into a struct
+ *
+ * @param msg The message to decode
+ * @param component_information_basic C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_component_information_basic_decode(const mavlink_message_t* msg, mavlink_component_information_basic_t* component_information_basic)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    component_information_basic->capabilities = mavlink_msg_component_information_basic_get_capabilities(msg);
+    component_information_basic->time_boot_ms = mavlink_msg_component_information_basic_get_time_boot_ms(msg);
+    mavlink_msg_component_information_basic_get_vendor_name(msg, component_information_basic->vendor_name);
+    mavlink_msg_component_information_basic_get_model_name(msg, component_information_basic->model_name);
+    mavlink_msg_component_information_basic_get_software_version(msg, component_information_basic->software_version);
+    mavlink_msg_component_information_basic_get_hardware_version(msg, component_information_basic->hardware_version);
+    mavlink_msg_component_information_basic_get_serial_number(msg, component_information_basic->serial_number);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN? msg->len : MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN;
+        memset(component_information_basic, 0, MAVLINK_MSG_ID_COMPONENT_INFORMATION_BASIC_LEN);
+    memcpy(component_information_basic, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_control_status.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_control_status.h
@@ -1,0 +1,288 @@
+#pragma once
+// MESSAGE CONTROL_STATUS PACKING
+
+#define MAVLINK_MSG_ID_CONTROL_STATUS 512
+
+
+typedef struct __mavlink_control_status_t {
+ uint8_t sysid_in_control; /*<  System ID of GCS MAVLink component in control (0: no GCS in control).*/
+ uint8_t flags; /*<  Control status. For example, whether takeover is allowed, and whether this message instance defines the default controlling GCS for the whole system.*/
+} mavlink_control_status_t;
+
+#define MAVLINK_MSG_ID_CONTROL_STATUS_LEN 2
+#define MAVLINK_MSG_ID_CONTROL_STATUS_MIN_LEN 2
+#define MAVLINK_MSG_ID_512_LEN 2
+#define MAVLINK_MSG_ID_512_MIN_LEN 2
+
+#define MAVLINK_MSG_ID_CONTROL_STATUS_CRC 184
+#define MAVLINK_MSG_ID_512_CRC 184
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_CONTROL_STATUS { \
+    512, \
+    "CONTROL_STATUS", \
+    2, \
+    {  { "sysid_in_control", NULL, MAVLINK_TYPE_UINT8_T, 0, 0, offsetof(mavlink_control_status_t, sysid_in_control) }, \
+         { "flags", NULL, MAVLINK_TYPE_UINT8_T, 0, 1, offsetof(mavlink_control_status_t, flags) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_CONTROL_STATUS { \
+    "CONTROL_STATUS", \
+    2, \
+    {  { "sysid_in_control", NULL, MAVLINK_TYPE_UINT8_T, 0, 0, offsetof(mavlink_control_status_t, sysid_in_control) }, \
+         { "flags", NULL, MAVLINK_TYPE_UINT8_T, 0, 1, offsetof(mavlink_control_status_t, flags) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a control_status message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param sysid_in_control  System ID of GCS MAVLink component in control (0: no GCS in control).
+ * @param flags  Control status. For example, whether takeover is allowed, and whether this message instance defines the default controlling GCS for the whole system.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_control_status_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint8_t sysid_in_control, uint8_t flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CONTROL_STATUS_LEN];
+    _mav_put_uint8_t(buf, 0, sysid_in_control);
+    _mav_put_uint8_t(buf, 1, flags);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_CONTROL_STATUS_LEN);
+#else
+    mavlink_control_status_t packet;
+    packet.sysid_in_control = sysid_in_control;
+    packet.flags = flags;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_CONTROL_STATUS_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_CONTROL_STATUS;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_CONTROL_STATUS_MIN_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_CRC);
+}
+
+/**
+ * @brief Pack a control_status message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param sysid_in_control  System ID of GCS MAVLink component in control (0: no GCS in control).
+ * @param flags  Control status. For example, whether takeover is allowed, and whether this message instance defines the default controlling GCS for the whole system.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_control_status_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint8_t sysid_in_control, uint8_t flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CONTROL_STATUS_LEN];
+    _mav_put_uint8_t(buf, 0, sysid_in_control);
+    _mav_put_uint8_t(buf, 1, flags);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_CONTROL_STATUS_LEN);
+#else
+    mavlink_control_status_t packet;
+    packet.sysid_in_control = sysid_in_control;
+    packet.flags = flags;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_CONTROL_STATUS_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_CONTROL_STATUS;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_CONTROL_STATUS_MIN_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_CONTROL_STATUS_MIN_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a control_status message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param sysid_in_control  System ID of GCS MAVLink component in control (0: no GCS in control).
+ * @param flags  Control status. For example, whether takeover is allowed, and whether this message instance defines the default controlling GCS for the whole system.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_control_status_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint8_t sysid_in_control,uint8_t flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CONTROL_STATUS_LEN];
+    _mav_put_uint8_t(buf, 0, sysid_in_control);
+    _mav_put_uint8_t(buf, 1, flags);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_CONTROL_STATUS_LEN);
+#else
+    mavlink_control_status_t packet;
+    packet.sysid_in_control = sysid_in_control;
+    packet.flags = flags;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_CONTROL_STATUS_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_CONTROL_STATUS;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_CONTROL_STATUS_MIN_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_CRC);
+}
+
+/**
+ * @brief Encode a control_status struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param control_status C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_control_status_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_control_status_t* control_status)
+{
+    return mavlink_msg_control_status_pack(system_id, component_id, msg, control_status->sysid_in_control, control_status->flags);
+}
+
+/**
+ * @brief Encode a control_status struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param control_status C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_control_status_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_control_status_t* control_status)
+{
+    return mavlink_msg_control_status_pack_chan(system_id, component_id, chan, msg, control_status->sysid_in_control, control_status->flags);
+}
+
+/**
+ * @brief Encode a control_status struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param control_status C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_control_status_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_control_status_t* control_status)
+{
+    return mavlink_msg_control_status_pack_status(system_id, component_id, _status, msg,  control_status->sysid_in_control, control_status->flags);
+}
+
+/**
+ * @brief Send a control_status message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param sysid_in_control  System ID of GCS MAVLink component in control (0: no GCS in control).
+ * @param flags  Control status. For example, whether takeover is allowed, and whether this message instance defines the default controlling GCS for the whole system.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_control_status_send(mavlink_channel_t chan, uint8_t sysid_in_control, uint8_t flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CONTROL_STATUS_LEN];
+    _mav_put_uint8_t(buf, 0, sysid_in_control);
+    _mav_put_uint8_t(buf, 1, flags);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CONTROL_STATUS, buf, MAVLINK_MSG_ID_CONTROL_STATUS_MIN_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_CRC);
+#else
+    mavlink_control_status_t packet;
+    packet.sysid_in_control = sysid_in_control;
+    packet.flags = flags;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CONTROL_STATUS, (const char *)&packet, MAVLINK_MSG_ID_CONTROL_STATUS_MIN_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_CRC);
+#endif
+}
+
+/**
+ * @brief Send a control_status message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_control_status_send_struct(mavlink_channel_t chan, const mavlink_control_status_t* control_status)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_control_status_send(chan, control_status->sysid_in_control, control_status->flags);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CONTROL_STATUS, (const char *)control_status, MAVLINK_MSG_ID_CONTROL_STATUS_MIN_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_CONTROL_STATUS_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_control_status_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint8_t sysid_in_control, uint8_t flags)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint8_t(buf, 0, sysid_in_control);
+    _mav_put_uint8_t(buf, 1, flags);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CONTROL_STATUS, buf, MAVLINK_MSG_ID_CONTROL_STATUS_MIN_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_CRC);
+#else
+    mavlink_control_status_t *packet = (mavlink_control_status_t *)msgbuf;
+    packet->sysid_in_control = sysid_in_control;
+    packet->flags = flags;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CONTROL_STATUS, (const char *)packet, MAVLINK_MSG_ID_CONTROL_STATUS_MIN_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_LEN, MAVLINK_MSG_ID_CONTROL_STATUS_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE CONTROL_STATUS UNPACKING
+
+
+/**
+ * @brief Get field sysid_in_control from control_status message
+ *
+ * @return  System ID of GCS MAVLink component in control (0: no GCS in control).
+ */
+static inline uint8_t mavlink_msg_control_status_get_sysid_in_control(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  0);
+}
+
+/**
+ * @brief Get field flags from control_status message
+ *
+ * @return  Control status. For example, whether takeover is allowed, and whether this message instance defines the default controlling GCS for the whole system.
+ */
+static inline uint8_t mavlink_msg_control_status_get_flags(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  1);
+}
+
+/**
+ * @brief Decode a control_status message into a struct
+ *
+ * @param msg The message to decode
+ * @param control_status C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_control_status_decode(const mavlink_message_t* msg, mavlink_control_status_t* control_status)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    control_status->sysid_in_control = mavlink_msg_control_status_get_sysid_in_control(msg);
+    control_status->flags = mavlink_msg_control_status_get_flags(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_CONTROL_STATUS_LEN? msg->len : MAVLINK_MSG_ID_CONTROL_STATUS_LEN;
+        memset(control_status, 0, MAVLINK_MSG_ID_CONTROL_STATUS_LEN);
+    memcpy(control_status, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_control_surface_cmd.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_control_surface_cmd.h
@@ -1,0 +1,372 @@
+#pragma once
+// MESSAGE CONTROL_SURFACE_CMD PACKING
+
+#define MAVLINK_MSG_ID_CONTROL_SURFACE_CMD 514
+
+
+typedef struct __mavlink_control_surface_cmd_t {
+ uint32_t time_boot_ms; /*< [ms] Timestamp (time since system boot).*/
+ float left_aileron; /*< [deg] Left aileron*/
+ float right_aileron; /*< [deg] Right aileron*/
+ float left_ruddervator; /*< [deg] Left ruddervator*/
+ float right_ruddervator; /*< [deg] Right ruddervator*/
+} mavlink_control_surface_cmd_t;
+
+#define MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN 20
+#define MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_MIN_LEN 20
+#define MAVLINK_MSG_ID_514_LEN 20
+#define MAVLINK_MSG_ID_514_MIN_LEN 20
+
+#define MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_CRC 79
+#define MAVLINK_MSG_ID_514_CRC 79
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_CONTROL_SURFACE_CMD { \
+    514, \
+    "CONTROL_SURFACE_CMD", \
+    5, \
+    {  { "time_boot_ms", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_control_surface_cmd_t, time_boot_ms) }, \
+         { "left_aileron", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_control_surface_cmd_t, left_aileron) }, \
+         { "right_aileron", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_control_surface_cmd_t, right_aileron) }, \
+         { "left_ruddervator", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_control_surface_cmd_t, left_ruddervator) }, \
+         { "right_ruddervator", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_control_surface_cmd_t, right_ruddervator) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_CONTROL_SURFACE_CMD { \
+    "CONTROL_SURFACE_CMD", \
+    5, \
+    {  { "time_boot_ms", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_control_surface_cmd_t, time_boot_ms) }, \
+         { "left_aileron", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_control_surface_cmd_t, left_aileron) }, \
+         { "right_aileron", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_control_surface_cmd_t, right_aileron) }, \
+         { "left_ruddervator", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_control_surface_cmd_t, left_ruddervator) }, \
+         { "right_ruddervator", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_control_surface_cmd_t, right_ruddervator) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a control_surface_cmd message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param left_aileron [deg] Left aileron
+ * @param right_aileron [deg] Right aileron
+ * @param left_ruddervator [deg] Left ruddervator
+ * @param right_ruddervator [deg] Right ruddervator
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_control_surface_cmd_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint32_t time_boot_ms, float left_aileron, float right_aileron, float left_ruddervator, float right_ruddervator)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, left_aileron);
+    _mav_put_float(buf, 8, right_aileron);
+    _mav_put_float(buf, 12, left_ruddervator);
+    _mav_put_float(buf, 16, right_ruddervator);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN);
+#else
+    mavlink_control_surface_cmd_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.left_aileron = left_aileron;
+    packet.right_aileron = right_aileron;
+    packet.left_ruddervator = left_ruddervator;
+    packet.right_ruddervator = right_ruddervator;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_CONTROL_SURFACE_CMD;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_MIN_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_CRC);
+}
+
+/**
+ * @brief Pack a control_surface_cmd message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param left_aileron [deg] Left aileron
+ * @param right_aileron [deg] Right aileron
+ * @param left_ruddervator [deg] Left ruddervator
+ * @param right_ruddervator [deg] Right ruddervator
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_control_surface_cmd_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint32_t time_boot_ms, float left_aileron, float right_aileron, float left_ruddervator, float right_ruddervator)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, left_aileron);
+    _mav_put_float(buf, 8, right_aileron);
+    _mav_put_float(buf, 12, left_ruddervator);
+    _mav_put_float(buf, 16, right_ruddervator);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN);
+#else
+    mavlink_control_surface_cmd_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.left_aileron = left_aileron;
+    packet.right_aileron = right_aileron;
+    packet.left_ruddervator = left_ruddervator;
+    packet.right_ruddervator = right_ruddervator;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_CONTROL_SURFACE_CMD;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_MIN_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_MIN_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a control_surface_cmd message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param left_aileron [deg] Left aileron
+ * @param right_aileron [deg] Right aileron
+ * @param left_ruddervator [deg] Left ruddervator
+ * @param right_ruddervator [deg] Right ruddervator
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_control_surface_cmd_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint32_t time_boot_ms,float left_aileron,float right_aileron,float left_ruddervator,float right_ruddervator)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, left_aileron);
+    _mav_put_float(buf, 8, right_aileron);
+    _mav_put_float(buf, 12, left_ruddervator);
+    _mav_put_float(buf, 16, right_ruddervator);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN);
+#else
+    mavlink_control_surface_cmd_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.left_aileron = left_aileron;
+    packet.right_aileron = right_aileron;
+    packet.left_ruddervator = left_ruddervator;
+    packet.right_ruddervator = right_ruddervator;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_CONTROL_SURFACE_CMD;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_MIN_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_CRC);
+}
+
+/**
+ * @brief Encode a control_surface_cmd struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param control_surface_cmd C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_control_surface_cmd_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_control_surface_cmd_t* control_surface_cmd)
+{
+    return mavlink_msg_control_surface_cmd_pack(system_id, component_id, msg, control_surface_cmd->time_boot_ms, control_surface_cmd->left_aileron, control_surface_cmd->right_aileron, control_surface_cmd->left_ruddervator, control_surface_cmd->right_ruddervator);
+}
+
+/**
+ * @brief Encode a control_surface_cmd struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param control_surface_cmd C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_control_surface_cmd_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_control_surface_cmd_t* control_surface_cmd)
+{
+    return mavlink_msg_control_surface_cmd_pack_chan(system_id, component_id, chan, msg, control_surface_cmd->time_boot_ms, control_surface_cmd->left_aileron, control_surface_cmd->right_aileron, control_surface_cmd->left_ruddervator, control_surface_cmd->right_ruddervator);
+}
+
+/**
+ * @brief Encode a control_surface_cmd struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param control_surface_cmd C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_control_surface_cmd_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_control_surface_cmd_t* control_surface_cmd)
+{
+    return mavlink_msg_control_surface_cmd_pack_status(system_id, component_id, _status, msg,  control_surface_cmd->time_boot_ms, control_surface_cmd->left_aileron, control_surface_cmd->right_aileron, control_surface_cmd->left_ruddervator, control_surface_cmd->right_ruddervator);
+}
+
+/**
+ * @brief Send a control_surface_cmd message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param left_aileron [deg] Left aileron
+ * @param right_aileron [deg] Right aileron
+ * @param left_ruddervator [deg] Left ruddervator
+ * @param right_ruddervator [deg] Right ruddervator
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_control_surface_cmd_send(mavlink_channel_t chan, uint32_t time_boot_ms, float left_aileron, float right_aileron, float left_ruddervator, float right_ruddervator)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, left_aileron);
+    _mav_put_float(buf, 8, right_aileron);
+    _mav_put_float(buf, 12, left_ruddervator);
+    _mav_put_float(buf, 16, right_ruddervator);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD, buf, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_MIN_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_CRC);
+#else
+    mavlink_control_surface_cmd_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.left_aileron = left_aileron;
+    packet.right_aileron = right_aileron;
+    packet.left_ruddervator = left_ruddervator;
+    packet.right_ruddervator = right_ruddervator;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD, (const char *)&packet, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_MIN_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_CRC);
+#endif
+}
+
+/**
+ * @brief Send a control_surface_cmd message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_control_surface_cmd_send_struct(mavlink_channel_t chan, const mavlink_control_surface_cmd_t* control_surface_cmd)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_control_surface_cmd_send(chan, control_surface_cmd->time_boot_ms, control_surface_cmd->left_aileron, control_surface_cmd->right_aileron, control_surface_cmd->left_ruddervator, control_surface_cmd->right_ruddervator);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD, (const char *)control_surface_cmd, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_MIN_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_control_surface_cmd_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint32_t time_boot_ms, float left_aileron, float right_aileron, float left_ruddervator, float right_ruddervator)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, left_aileron);
+    _mav_put_float(buf, 8, right_aileron);
+    _mav_put_float(buf, 12, left_ruddervator);
+    _mav_put_float(buf, 16, right_ruddervator);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD, buf, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_MIN_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_CRC);
+#else
+    mavlink_control_surface_cmd_t *packet = (mavlink_control_surface_cmd_t *)msgbuf;
+    packet->time_boot_ms = time_boot_ms;
+    packet->left_aileron = left_aileron;
+    packet->right_aileron = right_aileron;
+    packet->left_ruddervator = left_ruddervator;
+    packet->right_ruddervator = right_ruddervator;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD, (const char *)packet, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_MIN_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE CONTROL_SURFACE_CMD UNPACKING
+
+
+/**
+ * @brief Get field time_boot_ms from control_surface_cmd message
+ *
+ * @return [ms] Timestamp (time since system boot).
+ */
+static inline uint32_t mavlink_msg_control_surface_cmd_get_time_boot_ms(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  0);
+}
+
+/**
+ * @brief Get field left_aileron from control_surface_cmd message
+ *
+ * @return [deg] Left aileron
+ */
+static inline float mavlink_msg_control_surface_cmd_get_left_aileron(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  4);
+}
+
+/**
+ * @brief Get field right_aileron from control_surface_cmd message
+ *
+ * @return [deg] Right aileron
+ */
+static inline float mavlink_msg_control_surface_cmd_get_right_aileron(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  8);
+}
+
+/**
+ * @brief Get field left_ruddervator from control_surface_cmd message
+ *
+ * @return [deg] Left ruddervator
+ */
+static inline float mavlink_msg_control_surface_cmd_get_left_ruddervator(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  12);
+}
+
+/**
+ * @brief Get field right_ruddervator from control_surface_cmd message
+ *
+ * @return [deg] Right ruddervator
+ */
+static inline float mavlink_msg_control_surface_cmd_get_right_ruddervator(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  16);
+}
+
+/**
+ * @brief Decode a control_surface_cmd message into a struct
+ *
+ * @param msg The message to decode
+ * @param control_surface_cmd C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_control_surface_cmd_decode(const mavlink_message_t* msg, mavlink_control_surface_cmd_t* control_surface_cmd)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    control_surface_cmd->time_boot_ms = mavlink_msg_control_surface_cmd_get_time_boot_ms(msg);
+    control_surface_cmd->left_aileron = mavlink_msg_control_surface_cmd_get_left_aileron(msg);
+    control_surface_cmd->right_aileron = mavlink_msg_control_surface_cmd_get_right_aileron(msg);
+    control_surface_cmd->left_ruddervator = mavlink_msg_control_surface_cmd_get_left_ruddervator(msg);
+    control_surface_cmd->right_ruddervator = mavlink_msg_control_surface_cmd_get_right_ruddervator(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN? msg->len : MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN;
+        memset(control_surface_cmd, 0, MAVLINK_MSG_ID_CONTROL_SURFACE_CMD_LEN);
+    memcpy(control_surface_cmd, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_current_mode.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_current_mode.h
@@ -1,0 +1,316 @@
+#pragma once
+// MESSAGE CURRENT_MODE PACKING
+
+#define MAVLINK_MSG_ID_CURRENT_MODE 436
+
+
+typedef struct __mavlink_current_mode_t {
+ uint32_t custom_mode; /*<  A bitfield for use for autopilot-specific flags*/
+ uint32_t intended_custom_mode; /*<  The custom_mode of the mode that was last commanded by the user (for example, with MAV_CMD_DO_SET_STANDARD_MODE, MAV_CMD_DO_SET_MODE or via RC). This should usually be the same as custom_mode. It will be different if the vehicle is unable to enter the intended mode, or has left that mode due to a failsafe condition. 0 indicates the intended custom mode is unknown/not supplied*/
+ uint8_t standard_mode; /*<  Standard mode.*/
+} mavlink_current_mode_t;
+
+#define MAVLINK_MSG_ID_CURRENT_MODE_LEN 9
+#define MAVLINK_MSG_ID_CURRENT_MODE_MIN_LEN 9
+#define MAVLINK_MSG_ID_436_LEN 9
+#define MAVLINK_MSG_ID_436_MIN_LEN 9
+
+#define MAVLINK_MSG_ID_CURRENT_MODE_CRC 193
+#define MAVLINK_MSG_ID_436_CRC 193
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_CURRENT_MODE { \
+    436, \
+    "CURRENT_MODE", \
+    3, \
+    {  { "standard_mode", NULL, MAVLINK_TYPE_UINT8_T, 0, 8, offsetof(mavlink_current_mode_t, standard_mode) }, \
+         { "custom_mode", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_current_mode_t, custom_mode) }, \
+         { "intended_custom_mode", NULL, MAVLINK_TYPE_UINT32_T, 0, 4, offsetof(mavlink_current_mode_t, intended_custom_mode) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_CURRENT_MODE { \
+    "CURRENT_MODE", \
+    3, \
+    {  { "standard_mode", NULL, MAVLINK_TYPE_UINT8_T, 0, 8, offsetof(mavlink_current_mode_t, standard_mode) }, \
+         { "custom_mode", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_current_mode_t, custom_mode) }, \
+         { "intended_custom_mode", NULL, MAVLINK_TYPE_UINT32_T, 0, 4, offsetof(mavlink_current_mode_t, intended_custom_mode) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a current_mode message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param standard_mode  Standard mode.
+ * @param custom_mode  A bitfield for use for autopilot-specific flags
+ * @param intended_custom_mode  The custom_mode of the mode that was last commanded by the user (for example, with MAV_CMD_DO_SET_STANDARD_MODE, MAV_CMD_DO_SET_MODE or via RC). This should usually be the same as custom_mode. It will be different if the vehicle is unable to enter the intended mode, or has left that mode due to a failsafe condition. 0 indicates the intended custom mode is unknown/not supplied
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_current_mode_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint8_t standard_mode, uint32_t custom_mode, uint32_t intended_custom_mode)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CURRENT_MODE_LEN];
+    _mav_put_uint32_t(buf, 0, custom_mode);
+    _mav_put_uint32_t(buf, 4, intended_custom_mode);
+    _mav_put_uint8_t(buf, 8, standard_mode);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_CURRENT_MODE_LEN);
+#else
+    mavlink_current_mode_t packet;
+    packet.custom_mode = custom_mode;
+    packet.intended_custom_mode = intended_custom_mode;
+    packet.standard_mode = standard_mode;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_CURRENT_MODE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_CURRENT_MODE;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_CURRENT_MODE_MIN_LEN, MAVLINK_MSG_ID_CURRENT_MODE_LEN, MAVLINK_MSG_ID_CURRENT_MODE_CRC);
+}
+
+/**
+ * @brief Pack a current_mode message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param standard_mode  Standard mode.
+ * @param custom_mode  A bitfield for use for autopilot-specific flags
+ * @param intended_custom_mode  The custom_mode of the mode that was last commanded by the user (for example, with MAV_CMD_DO_SET_STANDARD_MODE, MAV_CMD_DO_SET_MODE or via RC). This should usually be the same as custom_mode. It will be different if the vehicle is unable to enter the intended mode, or has left that mode due to a failsafe condition. 0 indicates the intended custom mode is unknown/not supplied
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_current_mode_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint8_t standard_mode, uint32_t custom_mode, uint32_t intended_custom_mode)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CURRENT_MODE_LEN];
+    _mav_put_uint32_t(buf, 0, custom_mode);
+    _mav_put_uint32_t(buf, 4, intended_custom_mode);
+    _mav_put_uint8_t(buf, 8, standard_mode);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_CURRENT_MODE_LEN);
+#else
+    mavlink_current_mode_t packet;
+    packet.custom_mode = custom_mode;
+    packet.intended_custom_mode = intended_custom_mode;
+    packet.standard_mode = standard_mode;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_CURRENT_MODE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_CURRENT_MODE;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_CURRENT_MODE_MIN_LEN, MAVLINK_MSG_ID_CURRENT_MODE_LEN, MAVLINK_MSG_ID_CURRENT_MODE_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_CURRENT_MODE_MIN_LEN, MAVLINK_MSG_ID_CURRENT_MODE_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a current_mode message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param standard_mode  Standard mode.
+ * @param custom_mode  A bitfield for use for autopilot-specific flags
+ * @param intended_custom_mode  The custom_mode of the mode that was last commanded by the user (for example, with MAV_CMD_DO_SET_STANDARD_MODE, MAV_CMD_DO_SET_MODE or via RC). This should usually be the same as custom_mode. It will be different if the vehicle is unable to enter the intended mode, or has left that mode due to a failsafe condition. 0 indicates the intended custom mode is unknown/not supplied
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_current_mode_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint8_t standard_mode,uint32_t custom_mode,uint32_t intended_custom_mode)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CURRENT_MODE_LEN];
+    _mav_put_uint32_t(buf, 0, custom_mode);
+    _mav_put_uint32_t(buf, 4, intended_custom_mode);
+    _mav_put_uint8_t(buf, 8, standard_mode);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_CURRENT_MODE_LEN);
+#else
+    mavlink_current_mode_t packet;
+    packet.custom_mode = custom_mode;
+    packet.intended_custom_mode = intended_custom_mode;
+    packet.standard_mode = standard_mode;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_CURRENT_MODE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_CURRENT_MODE;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_CURRENT_MODE_MIN_LEN, MAVLINK_MSG_ID_CURRENT_MODE_LEN, MAVLINK_MSG_ID_CURRENT_MODE_CRC);
+}
+
+/**
+ * @brief Encode a current_mode struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param current_mode C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_current_mode_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_current_mode_t* current_mode)
+{
+    return mavlink_msg_current_mode_pack(system_id, component_id, msg, current_mode->standard_mode, current_mode->custom_mode, current_mode->intended_custom_mode);
+}
+
+/**
+ * @brief Encode a current_mode struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param current_mode C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_current_mode_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_current_mode_t* current_mode)
+{
+    return mavlink_msg_current_mode_pack_chan(system_id, component_id, chan, msg, current_mode->standard_mode, current_mode->custom_mode, current_mode->intended_custom_mode);
+}
+
+/**
+ * @brief Encode a current_mode struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param current_mode C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_current_mode_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_current_mode_t* current_mode)
+{
+    return mavlink_msg_current_mode_pack_status(system_id, component_id, _status, msg,  current_mode->standard_mode, current_mode->custom_mode, current_mode->intended_custom_mode);
+}
+
+/**
+ * @brief Send a current_mode message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param standard_mode  Standard mode.
+ * @param custom_mode  A bitfield for use for autopilot-specific flags
+ * @param intended_custom_mode  The custom_mode of the mode that was last commanded by the user (for example, with MAV_CMD_DO_SET_STANDARD_MODE, MAV_CMD_DO_SET_MODE or via RC). This should usually be the same as custom_mode. It will be different if the vehicle is unable to enter the intended mode, or has left that mode due to a failsafe condition. 0 indicates the intended custom mode is unknown/not supplied
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_current_mode_send(mavlink_channel_t chan, uint8_t standard_mode, uint32_t custom_mode, uint32_t intended_custom_mode)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_CURRENT_MODE_LEN];
+    _mav_put_uint32_t(buf, 0, custom_mode);
+    _mav_put_uint32_t(buf, 4, intended_custom_mode);
+    _mav_put_uint8_t(buf, 8, standard_mode);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CURRENT_MODE, buf, MAVLINK_MSG_ID_CURRENT_MODE_MIN_LEN, MAVLINK_MSG_ID_CURRENT_MODE_LEN, MAVLINK_MSG_ID_CURRENT_MODE_CRC);
+#else
+    mavlink_current_mode_t packet;
+    packet.custom_mode = custom_mode;
+    packet.intended_custom_mode = intended_custom_mode;
+    packet.standard_mode = standard_mode;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CURRENT_MODE, (const char *)&packet, MAVLINK_MSG_ID_CURRENT_MODE_MIN_LEN, MAVLINK_MSG_ID_CURRENT_MODE_LEN, MAVLINK_MSG_ID_CURRENT_MODE_CRC);
+#endif
+}
+
+/**
+ * @brief Send a current_mode message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_current_mode_send_struct(mavlink_channel_t chan, const mavlink_current_mode_t* current_mode)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_current_mode_send(chan, current_mode->standard_mode, current_mode->custom_mode, current_mode->intended_custom_mode);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CURRENT_MODE, (const char *)current_mode, MAVLINK_MSG_ID_CURRENT_MODE_MIN_LEN, MAVLINK_MSG_ID_CURRENT_MODE_LEN, MAVLINK_MSG_ID_CURRENT_MODE_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_CURRENT_MODE_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_current_mode_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint8_t standard_mode, uint32_t custom_mode, uint32_t intended_custom_mode)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint32_t(buf, 0, custom_mode);
+    _mav_put_uint32_t(buf, 4, intended_custom_mode);
+    _mav_put_uint8_t(buf, 8, standard_mode);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CURRENT_MODE, buf, MAVLINK_MSG_ID_CURRENT_MODE_MIN_LEN, MAVLINK_MSG_ID_CURRENT_MODE_LEN, MAVLINK_MSG_ID_CURRENT_MODE_CRC);
+#else
+    mavlink_current_mode_t *packet = (mavlink_current_mode_t *)msgbuf;
+    packet->custom_mode = custom_mode;
+    packet->intended_custom_mode = intended_custom_mode;
+    packet->standard_mode = standard_mode;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_CURRENT_MODE, (const char *)packet, MAVLINK_MSG_ID_CURRENT_MODE_MIN_LEN, MAVLINK_MSG_ID_CURRENT_MODE_LEN, MAVLINK_MSG_ID_CURRENT_MODE_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE CURRENT_MODE UNPACKING
+
+
+/**
+ * @brief Get field standard_mode from current_mode message
+ *
+ * @return  Standard mode.
+ */
+static inline uint8_t mavlink_msg_current_mode_get_standard_mode(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  8);
+}
+
+/**
+ * @brief Get field custom_mode from current_mode message
+ *
+ * @return  A bitfield for use for autopilot-specific flags
+ */
+static inline uint32_t mavlink_msg_current_mode_get_custom_mode(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  0);
+}
+
+/**
+ * @brief Get field intended_custom_mode from current_mode message
+ *
+ * @return  The custom_mode of the mode that was last commanded by the user (for example, with MAV_CMD_DO_SET_STANDARD_MODE, MAV_CMD_DO_SET_MODE or via RC). This should usually be the same as custom_mode. It will be different if the vehicle is unable to enter the intended mode, or has left that mode due to a failsafe condition. 0 indicates the intended custom mode is unknown/not supplied
+ */
+static inline uint32_t mavlink_msg_current_mode_get_intended_custom_mode(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  4);
+}
+
+/**
+ * @brief Decode a current_mode message into a struct
+ *
+ * @param msg The message to decode
+ * @param current_mode C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_current_mode_decode(const mavlink_message_t* msg, mavlink_current_mode_t* current_mode)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    current_mode->custom_mode = mavlink_msg_current_mode_get_custom_mode(msg);
+    current_mode->intended_custom_mode = mavlink_msg_current_mode_get_intended_custom_mode(msg);
+    current_mode->standard_mode = mavlink_msg_current_mode_get_standard_mode(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_CURRENT_MODE_LEN? msg->len : MAVLINK_MSG_ID_CURRENT_MODE_LEN;
+        memset(current_mode, 0, MAVLINK_MSG_ID_CURRENT_MODE_LEN);
+    memcpy(current_mode, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_esc_hbci_monitor.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_esc_hbci_monitor.h
@@ -1,0 +1,1044 @@
+#pragma once
+// MESSAGE ESC_HBCI_MONITOR PACKING
+
+#define MAVLINK_MSG_ID_ESC_HBCI_MONITOR 515
+
+
+typedef struct __mavlink_esc_hbci_monitor_t {
+ uint32_t time_boot_ms; /*< [ms] Timestamp (time since system boot).*/
+ float voltage_fl; /*< [V] Front left voltage*/
+ float voltage_fr; /*< [V] Front right voltage*/
+ float voltage_rl; /*< [V] Rear left voltage*/
+ float voltage_rr; /*< [V] Rear right voltage*/
+ float current_fl; /*< [A] Front left current*/
+ float current_fr; /*< [A] Front right current*/
+ float current_rl; /*< [A] Rear left current*/
+ float current_rr; /*< [A] Rear right current*/
+ int32_t rpm_fl; /*< [RPM] Front left RPM*/
+ int32_t rpm_fr; /*< [RPM] Front right RPM*/
+ int32_t rpm_rl; /*< [RPM] Rear left RPM*/
+ int32_t rpm_rr; /*< [RPM] Rear right RPM*/
+ int32_t motor_temper_fl; /*< [degC] Front left motor temperature*/
+ int32_t motor_temper_fr; /*< [degC] Front right motor temperature*/
+ int32_t motor_temper_rl; /*< [degC] Rear left motor temperature*/
+ int32_t motor_temper_rr; /*< [degC] Rear right motor temperature*/
+ int32_t esc_temper_fl; /*< [degC] Front left ESC temperature*/
+ int32_t esc_temper_fr; /*< [degC] Front right ESC temperature*/
+ int32_t esc_temper_rl; /*< [degC] Rear left ESC temperature*/
+ int32_t esc_temper_rr; /*< [degC] Rear right ESC temperature*/
+ float output_pwm_fl; /*< [%] Front left output PWM*/
+ float output_pwm_fr; /*< [%] Front right output PWM*/
+ float output_pwm_rl; /*< [%] Rear left output PWM*/
+ float output_pwm_rr; /*< [%] Rear right output PWM*/
+ float input_pwm_fl; /*< [%] Front left input PWM*/
+ float input_pwm_fr; /*< [%] Front right input PWM*/
+ float input_pwm_rl; /*< [%] Rear left input PWM*/
+ float input_pwm_rr; /*< [%] Rear right input PWM*/
+} mavlink_esc_hbci_monitor_t;
+
+#define MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN 116
+#define MAVLINK_MSG_ID_ESC_HBCI_MONITOR_MIN_LEN 116
+#define MAVLINK_MSG_ID_515_LEN 116
+#define MAVLINK_MSG_ID_515_MIN_LEN 116
+
+#define MAVLINK_MSG_ID_ESC_HBCI_MONITOR_CRC 205
+#define MAVLINK_MSG_ID_515_CRC 205
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_ESC_HBCI_MONITOR { \
+    515, \
+    "ESC_HBCI_MONITOR", \
+    29, \
+    {  { "time_boot_ms", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_esc_hbci_monitor_t, time_boot_ms) }, \
+         { "voltage_fl", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_esc_hbci_monitor_t, voltage_fl) }, \
+         { "voltage_fr", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_esc_hbci_monitor_t, voltage_fr) }, \
+         { "voltage_rl", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_esc_hbci_monitor_t, voltage_rl) }, \
+         { "voltage_rr", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_esc_hbci_monitor_t, voltage_rr) }, \
+         { "current_fl", NULL, MAVLINK_TYPE_FLOAT, 0, 20, offsetof(mavlink_esc_hbci_monitor_t, current_fl) }, \
+         { "current_fr", NULL, MAVLINK_TYPE_FLOAT, 0, 24, offsetof(mavlink_esc_hbci_monitor_t, current_fr) }, \
+         { "current_rl", NULL, MAVLINK_TYPE_FLOAT, 0, 28, offsetof(mavlink_esc_hbci_monitor_t, current_rl) }, \
+         { "current_rr", NULL, MAVLINK_TYPE_FLOAT, 0, 32, offsetof(mavlink_esc_hbci_monitor_t, current_rr) }, \
+         { "rpm_fl", NULL, MAVLINK_TYPE_INT32_T, 0, 36, offsetof(mavlink_esc_hbci_monitor_t, rpm_fl) }, \
+         { "rpm_fr", NULL, MAVLINK_TYPE_INT32_T, 0, 40, offsetof(mavlink_esc_hbci_monitor_t, rpm_fr) }, \
+         { "rpm_rl", NULL, MAVLINK_TYPE_INT32_T, 0, 44, offsetof(mavlink_esc_hbci_monitor_t, rpm_rl) }, \
+         { "rpm_rr", NULL, MAVLINK_TYPE_INT32_T, 0, 48, offsetof(mavlink_esc_hbci_monitor_t, rpm_rr) }, \
+         { "motor_temper_fl", NULL, MAVLINK_TYPE_INT32_T, 0, 52, offsetof(mavlink_esc_hbci_monitor_t, motor_temper_fl) }, \
+         { "motor_temper_fr", NULL, MAVLINK_TYPE_INT32_T, 0, 56, offsetof(mavlink_esc_hbci_monitor_t, motor_temper_fr) }, \
+         { "motor_temper_rl", NULL, MAVLINK_TYPE_INT32_T, 0, 60, offsetof(mavlink_esc_hbci_monitor_t, motor_temper_rl) }, \
+         { "motor_temper_rr", NULL, MAVLINK_TYPE_INT32_T, 0, 64, offsetof(mavlink_esc_hbci_monitor_t, motor_temper_rr) }, \
+         { "esc_temper_fl", NULL, MAVLINK_TYPE_INT32_T, 0, 68, offsetof(mavlink_esc_hbci_monitor_t, esc_temper_fl) }, \
+         { "esc_temper_fr", NULL, MAVLINK_TYPE_INT32_T, 0, 72, offsetof(mavlink_esc_hbci_monitor_t, esc_temper_fr) }, \
+         { "esc_temper_rl", NULL, MAVLINK_TYPE_INT32_T, 0, 76, offsetof(mavlink_esc_hbci_monitor_t, esc_temper_rl) }, \
+         { "esc_temper_rr", NULL, MAVLINK_TYPE_INT32_T, 0, 80, offsetof(mavlink_esc_hbci_monitor_t, esc_temper_rr) }, \
+         { "output_pwm_fl", NULL, MAVLINK_TYPE_FLOAT, 0, 84, offsetof(mavlink_esc_hbci_monitor_t, output_pwm_fl) }, \
+         { "output_pwm_fr", NULL, MAVLINK_TYPE_FLOAT, 0, 88, offsetof(mavlink_esc_hbci_monitor_t, output_pwm_fr) }, \
+         { "output_pwm_rl", NULL, MAVLINK_TYPE_FLOAT, 0, 92, offsetof(mavlink_esc_hbci_monitor_t, output_pwm_rl) }, \
+         { "output_pwm_rr", NULL, MAVLINK_TYPE_FLOAT, 0, 96, offsetof(mavlink_esc_hbci_monitor_t, output_pwm_rr) }, \
+         { "input_pwm_fl", NULL, MAVLINK_TYPE_FLOAT, 0, 100, offsetof(mavlink_esc_hbci_monitor_t, input_pwm_fl) }, \
+         { "input_pwm_fr", NULL, MAVLINK_TYPE_FLOAT, 0, 104, offsetof(mavlink_esc_hbci_monitor_t, input_pwm_fr) }, \
+         { "input_pwm_rl", NULL, MAVLINK_TYPE_FLOAT, 0, 108, offsetof(mavlink_esc_hbci_monitor_t, input_pwm_rl) }, \
+         { "input_pwm_rr", NULL, MAVLINK_TYPE_FLOAT, 0, 112, offsetof(mavlink_esc_hbci_monitor_t, input_pwm_rr) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_ESC_HBCI_MONITOR { \
+    "ESC_HBCI_MONITOR", \
+    29, \
+    {  { "time_boot_ms", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_esc_hbci_monitor_t, time_boot_ms) }, \
+         { "voltage_fl", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_esc_hbci_monitor_t, voltage_fl) }, \
+         { "voltage_fr", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_esc_hbci_monitor_t, voltage_fr) }, \
+         { "voltage_rl", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_esc_hbci_monitor_t, voltage_rl) }, \
+         { "voltage_rr", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_esc_hbci_monitor_t, voltage_rr) }, \
+         { "current_fl", NULL, MAVLINK_TYPE_FLOAT, 0, 20, offsetof(mavlink_esc_hbci_monitor_t, current_fl) }, \
+         { "current_fr", NULL, MAVLINK_TYPE_FLOAT, 0, 24, offsetof(mavlink_esc_hbci_monitor_t, current_fr) }, \
+         { "current_rl", NULL, MAVLINK_TYPE_FLOAT, 0, 28, offsetof(mavlink_esc_hbci_monitor_t, current_rl) }, \
+         { "current_rr", NULL, MAVLINK_TYPE_FLOAT, 0, 32, offsetof(mavlink_esc_hbci_monitor_t, current_rr) }, \
+         { "rpm_fl", NULL, MAVLINK_TYPE_INT32_T, 0, 36, offsetof(mavlink_esc_hbci_monitor_t, rpm_fl) }, \
+         { "rpm_fr", NULL, MAVLINK_TYPE_INT32_T, 0, 40, offsetof(mavlink_esc_hbci_monitor_t, rpm_fr) }, \
+         { "rpm_rl", NULL, MAVLINK_TYPE_INT32_T, 0, 44, offsetof(mavlink_esc_hbci_monitor_t, rpm_rl) }, \
+         { "rpm_rr", NULL, MAVLINK_TYPE_INT32_T, 0, 48, offsetof(mavlink_esc_hbci_monitor_t, rpm_rr) }, \
+         { "motor_temper_fl", NULL, MAVLINK_TYPE_INT32_T, 0, 52, offsetof(mavlink_esc_hbci_monitor_t, motor_temper_fl) }, \
+         { "motor_temper_fr", NULL, MAVLINK_TYPE_INT32_T, 0, 56, offsetof(mavlink_esc_hbci_monitor_t, motor_temper_fr) }, \
+         { "motor_temper_rl", NULL, MAVLINK_TYPE_INT32_T, 0, 60, offsetof(mavlink_esc_hbci_monitor_t, motor_temper_rl) }, \
+         { "motor_temper_rr", NULL, MAVLINK_TYPE_INT32_T, 0, 64, offsetof(mavlink_esc_hbci_monitor_t, motor_temper_rr) }, \
+         { "esc_temper_fl", NULL, MAVLINK_TYPE_INT32_T, 0, 68, offsetof(mavlink_esc_hbci_monitor_t, esc_temper_fl) }, \
+         { "esc_temper_fr", NULL, MAVLINK_TYPE_INT32_T, 0, 72, offsetof(mavlink_esc_hbci_monitor_t, esc_temper_fr) }, \
+         { "esc_temper_rl", NULL, MAVLINK_TYPE_INT32_T, 0, 76, offsetof(mavlink_esc_hbci_monitor_t, esc_temper_rl) }, \
+         { "esc_temper_rr", NULL, MAVLINK_TYPE_INT32_T, 0, 80, offsetof(mavlink_esc_hbci_monitor_t, esc_temper_rr) }, \
+         { "output_pwm_fl", NULL, MAVLINK_TYPE_FLOAT, 0, 84, offsetof(mavlink_esc_hbci_monitor_t, output_pwm_fl) }, \
+         { "output_pwm_fr", NULL, MAVLINK_TYPE_FLOAT, 0, 88, offsetof(mavlink_esc_hbci_monitor_t, output_pwm_fr) }, \
+         { "output_pwm_rl", NULL, MAVLINK_TYPE_FLOAT, 0, 92, offsetof(mavlink_esc_hbci_monitor_t, output_pwm_rl) }, \
+         { "output_pwm_rr", NULL, MAVLINK_TYPE_FLOAT, 0, 96, offsetof(mavlink_esc_hbci_monitor_t, output_pwm_rr) }, \
+         { "input_pwm_fl", NULL, MAVLINK_TYPE_FLOAT, 0, 100, offsetof(mavlink_esc_hbci_monitor_t, input_pwm_fl) }, \
+         { "input_pwm_fr", NULL, MAVLINK_TYPE_FLOAT, 0, 104, offsetof(mavlink_esc_hbci_monitor_t, input_pwm_fr) }, \
+         { "input_pwm_rl", NULL, MAVLINK_TYPE_FLOAT, 0, 108, offsetof(mavlink_esc_hbci_monitor_t, input_pwm_rl) }, \
+         { "input_pwm_rr", NULL, MAVLINK_TYPE_FLOAT, 0, 112, offsetof(mavlink_esc_hbci_monitor_t, input_pwm_rr) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a esc_hbci_monitor message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param voltage_fl [V] Front left voltage
+ * @param voltage_fr [V] Front right voltage
+ * @param voltage_rl [V] Rear left voltage
+ * @param voltage_rr [V] Rear right voltage
+ * @param current_fl [A] Front left current
+ * @param current_fr [A] Front right current
+ * @param current_rl [A] Rear left current
+ * @param current_rr [A] Rear right current
+ * @param rpm_fl [RPM] Front left RPM
+ * @param rpm_fr [RPM] Front right RPM
+ * @param rpm_rl [RPM] Rear left RPM
+ * @param rpm_rr [RPM] Rear right RPM
+ * @param motor_temper_fl [degC] Front left motor temperature
+ * @param motor_temper_fr [degC] Front right motor temperature
+ * @param motor_temper_rl [degC] Rear left motor temperature
+ * @param motor_temper_rr [degC] Rear right motor temperature
+ * @param esc_temper_fl [degC] Front left ESC temperature
+ * @param esc_temper_fr [degC] Front right ESC temperature
+ * @param esc_temper_rl [degC] Rear left ESC temperature
+ * @param esc_temper_rr [degC] Rear right ESC temperature
+ * @param output_pwm_fl [%] Front left output PWM
+ * @param output_pwm_fr [%] Front right output PWM
+ * @param output_pwm_rl [%] Rear left output PWM
+ * @param output_pwm_rr [%] Rear right output PWM
+ * @param input_pwm_fl [%] Front left input PWM
+ * @param input_pwm_fr [%] Front right input PWM
+ * @param input_pwm_rl [%] Rear left input PWM
+ * @param input_pwm_rr [%] Rear right input PWM
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_esc_hbci_monitor_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint32_t time_boot_ms, float voltage_fl, float voltage_fr, float voltage_rl, float voltage_rr, float current_fl, float current_fr, float current_rl, float current_rr, int32_t rpm_fl, int32_t rpm_fr, int32_t rpm_rl, int32_t rpm_rr, int32_t motor_temper_fl, int32_t motor_temper_fr, int32_t motor_temper_rl, int32_t motor_temper_rr, int32_t esc_temper_fl, int32_t esc_temper_fr, int32_t esc_temper_rl, int32_t esc_temper_rr, float output_pwm_fl, float output_pwm_fr, float output_pwm_rl, float output_pwm_rr, float input_pwm_fl, float input_pwm_fr, float input_pwm_rl, float input_pwm_rr)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, voltage_fl);
+    _mav_put_float(buf, 8, voltage_fr);
+    _mav_put_float(buf, 12, voltage_rl);
+    _mav_put_float(buf, 16, voltage_rr);
+    _mav_put_float(buf, 20, current_fl);
+    _mav_put_float(buf, 24, current_fr);
+    _mav_put_float(buf, 28, current_rl);
+    _mav_put_float(buf, 32, current_rr);
+    _mav_put_int32_t(buf, 36, rpm_fl);
+    _mav_put_int32_t(buf, 40, rpm_fr);
+    _mav_put_int32_t(buf, 44, rpm_rl);
+    _mav_put_int32_t(buf, 48, rpm_rr);
+    _mav_put_int32_t(buf, 52, motor_temper_fl);
+    _mav_put_int32_t(buf, 56, motor_temper_fr);
+    _mav_put_int32_t(buf, 60, motor_temper_rl);
+    _mav_put_int32_t(buf, 64, motor_temper_rr);
+    _mav_put_int32_t(buf, 68, esc_temper_fl);
+    _mav_put_int32_t(buf, 72, esc_temper_fr);
+    _mav_put_int32_t(buf, 76, esc_temper_rl);
+    _mav_put_int32_t(buf, 80, esc_temper_rr);
+    _mav_put_float(buf, 84, output_pwm_fl);
+    _mav_put_float(buf, 88, output_pwm_fr);
+    _mav_put_float(buf, 92, output_pwm_rl);
+    _mav_put_float(buf, 96, output_pwm_rr);
+    _mav_put_float(buf, 100, input_pwm_fl);
+    _mav_put_float(buf, 104, input_pwm_fr);
+    _mav_put_float(buf, 108, input_pwm_rl);
+    _mav_put_float(buf, 112, input_pwm_rr);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN);
+#else
+    mavlink_esc_hbci_monitor_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.voltage_fl = voltage_fl;
+    packet.voltage_fr = voltage_fr;
+    packet.voltage_rl = voltage_rl;
+    packet.voltage_rr = voltage_rr;
+    packet.current_fl = current_fl;
+    packet.current_fr = current_fr;
+    packet.current_rl = current_rl;
+    packet.current_rr = current_rr;
+    packet.rpm_fl = rpm_fl;
+    packet.rpm_fr = rpm_fr;
+    packet.rpm_rl = rpm_rl;
+    packet.rpm_rr = rpm_rr;
+    packet.motor_temper_fl = motor_temper_fl;
+    packet.motor_temper_fr = motor_temper_fr;
+    packet.motor_temper_rl = motor_temper_rl;
+    packet.motor_temper_rr = motor_temper_rr;
+    packet.esc_temper_fl = esc_temper_fl;
+    packet.esc_temper_fr = esc_temper_fr;
+    packet.esc_temper_rl = esc_temper_rl;
+    packet.esc_temper_rr = esc_temper_rr;
+    packet.output_pwm_fl = output_pwm_fl;
+    packet.output_pwm_fr = output_pwm_fr;
+    packet.output_pwm_rl = output_pwm_rl;
+    packet.output_pwm_rr = output_pwm_rr;
+    packet.input_pwm_fl = input_pwm_fl;
+    packet.input_pwm_fr = input_pwm_fr;
+    packet.input_pwm_rl = input_pwm_rl;
+    packet.input_pwm_rr = input_pwm_rr;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_ESC_HBCI_MONITOR;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_MIN_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_CRC);
+}
+
+/**
+ * @brief Pack a esc_hbci_monitor message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param voltage_fl [V] Front left voltage
+ * @param voltage_fr [V] Front right voltage
+ * @param voltage_rl [V] Rear left voltage
+ * @param voltage_rr [V] Rear right voltage
+ * @param current_fl [A] Front left current
+ * @param current_fr [A] Front right current
+ * @param current_rl [A] Rear left current
+ * @param current_rr [A] Rear right current
+ * @param rpm_fl [RPM] Front left RPM
+ * @param rpm_fr [RPM] Front right RPM
+ * @param rpm_rl [RPM] Rear left RPM
+ * @param rpm_rr [RPM] Rear right RPM
+ * @param motor_temper_fl [degC] Front left motor temperature
+ * @param motor_temper_fr [degC] Front right motor temperature
+ * @param motor_temper_rl [degC] Rear left motor temperature
+ * @param motor_temper_rr [degC] Rear right motor temperature
+ * @param esc_temper_fl [degC] Front left ESC temperature
+ * @param esc_temper_fr [degC] Front right ESC temperature
+ * @param esc_temper_rl [degC] Rear left ESC temperature
+ * @param esc_temper_rr [degC] Rear right ESC temperature
+ * @param output_pwm_fl [%] Front left output PWM
+ * @param output_pwm_fr [%] Front right output PWM
+ * @param output_pwm_rl [%] Rear left output PWM
+ * @param output_pwm_rr [%] Rear right output PWM
+ * @param input_pwm_fl [%] Front left input PWM
+ * @param input_pwm_fr [%] Front right input PWM
+ * @param input_pwm_rl [%] Rear left input PWM
+ * @param input_pwm_rr [%] Rear right input PWM
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_esc_hbci_monitor_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint32_t time_boot_ms, float voltage_fl, float voltage_fr, float voltage_rl, float voltage_rr, float current_fl, float current_fr, float current_rl, float current_rr, int32_t rpm_fl, int32_t rpm_fr, int32_t rpm_rl, int32_t rpm_rr, int32_t motor_temper_fl, int32_t motor_temper_fr, int32_t motor_temper_rl, int32_t motor_temper_rr, int32_t esc_temper_fl, int32_t esc_temper_fr, int32_t esc_temper_rl, int32_t esc_temper_rr, float output_pwm_fl, float output_pwm_fr, float output_pwm_rl, float output_pwm_rr, float input_pwm_fl, float input_pwm_fr, float input_pwm_rl, float input_pwm_rr)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, voltage_fl);
+    _mav_put_float(buf, 8, voltage_fr);
+    _mav_put_float(buf, 12, voltage_rl);
+    _mav_put_float(buf, 16, voltage_rr);
+    _mav_put_float(buf, 20, current_fl);
+    _mav_put_float(buf, 24, current_fr);
+    _mav_put_float(buf, 28, current_rl);
+    _mav_put_float(buf, 32, current_rr);
+    _mav_put_int32_t(buf, 36, rpm_fl);
+    _mav_put_int32_t(buf, 40, rpm_fr);
+    _mav_put_int32_t(buf, 44, rpm_rl);
+    _mav_put_int32_t(buf, 48, rpm_rr);
+    _mav_put_int32_t(buf, 52, motor_temper_fl);
+    _mav_put_int32_t(buf, 56, motor_temper_fr);
+    _mav_put_int32_t(buf, 60, motor_temper_rl);
+    _mav_put_int32_t(buf, 64, motor_temper_rr);
+    _mav_put_int32_t(buf, 68, esc_temper_fl);
+    _mav_put_int32_t(buf, 72, esc_temper_fr);
+    _mav_put_int32_t(buf, 76, esc_temper_rl);
+    _mav_put_int32_t(buf, 80, esc_temper_rr);
+    _mav_put_float(buf, 84, output_pwm_fl);
+    _mav_put_float(buf, 88, output_pwm_fr);
+    _mav_put_float(buf, 92, output_pwm_rl);
+    _mav_put_float(buf, 96, output_pwm_rr);
+    _mav_put_float(buf, 100, input_pwm_fl);
+    _mav_put_float(buf, 104, input_pwm_fr);
+    _mav_put_float(buf, 108, input_pwm_rl);
+    _mav_put_float(buf, 112, input_pwm_rr);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN);
+#else
+    mavlink_esc_hbci_monitor_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.voltage_fl = voltage_fl;
+    packet.voltage_fr = voltage_fr;
+    packet.voltage_rl = voltage_rl;
+    packet.voltage_rr = voltage_rr;
+    packet.current_fl = current_fl;
+    packet.current_fr = current_fr;
+    packet.current_rl = current_rl;
+    packet.current_rr = current_rr;
+    packet.rpm_fl = rpm_fl;
+    packet.rpm_fr = rpm_fr;
+    packet.rpm_rl = rpm_rl;
+    packet.rpm_rr = rpm_rr;
+    packet.motor_temper_fl = motor_temper_fl;
+    packet.motor_temper_fr = motor_temper_fr;
+    packet.motor_temper_rl = motor_temper_rl;
+    packet.motor_temper_rr = motor_temper_rr;
+    packet.esc_temper_fl = esc_temper_fl;
+    packet.esc_temper_fr = esc_temper_fr;
+    packet.esc_temper_rl = esc_temper_rl;
+    packet.esc_temper_rr = esc_temper_rr;
+    packet.output_pwm_fl = output_pwm_fl;
+    packet.output_pwm_fr = output_pwm_fr;
+    packet.output_pwm_rl = output_pwm_rl;
+    packet.output_pwm_rr = output_pwm_rr;
+    packet.input_pwm_fl = input_pwm_fl;
+    packet.input_pwm_fr = input_pwm_fr;
+    packet.input_pwm_rl = input_pwm_rl;
+    packet.input_pwm_rr = input_pwm_rr;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_ESC_HBCI_MONITOR;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_MIN_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_MIN_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a esc_hbci_monitor message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param voltage_fl [V] Front left voltage
+ * @param voltage_fr [V] Front right voltage
+ * @param voltage_rl [V] Rear left voltage
+ * @param voltage_rr [V] Rear right voltage
+ * @param current_fl [A] Front left current
+ * @param current_fr [A] Front right current
+ * @param current_rl [A] Rear left current
+ * @param current_rr [A] Rear right current
+ * @param rpm_fl [RPM] Front left RPM
+ * @param rpm_fr [RPM] Front right RPM
+ * @param rpm_rl [RPM] Rear left RPM
+ * @param rpm_rr [RPM] Rear right RPM
+ * @param motor_temper_fl [degC] Front left motor temperature
+ * @param motor_temper_fr [degC] Front right motor temperature
+ * @param motor_temper_rl [degC] Rear left motor temperature
+ * @param motor_temper_rr [degC] Rear right motor temperature
+ * @param esc_temper_fl [degC] Front left ESC temperature
+ * @param esc_temper_fr [degC] Front right ESC temperature
+ * @param esc_temper_rl [degC] Rear left ESC temperature
+ * @param esc_temper_rr [degC] Rear right ESC temperature
+ * @param output_pwm_fl [%] Front left output PWM
+ * @param output_pwm_fr [%] Front right output PWM
+ * @param output_pwm_rl [%] Rear left output PWM
+ * @param output_pwm_rr [%] Rear right output PWM
+ * @param input_pwm_fl [%] Front left input PWM
+ * @param input_pwm_fr [%] Front right input PWM
+ * @param input_pwm_rl [%] Rear left input PWM
+ * @param input_pwm_rr [%] Rear right input PWM
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_esc_hbci_monitor_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint32_t time_boot_ms,float voltage_fl,float voltage_fr,float voltage_rl,float voltage_rr,float current_fl,float current_fr,float current_rl,float current_rr,int32_t rpm_fl,int32_t rpm_fr,int32_t rpm_rl,int32_t rpm_rr,int32_t motor_temper_fl,int32_t motor_temper_fr,int32_t motor_temper_rl,int32_t motor_temper_rr,int32_t esc_temper_fl,int32_t esc_temper_fr,int32_t esc_temper_rl,int32_t esc_temper_rr,float output_pwm_fl,float output_pwm_fr,float output_pwm_rl,float output_pwm_rr,float input_pwm_fl,float input_pwm_fr,float input_pwm_rl,float input_pwm_rr)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, voltage_fl);
+    _mav_put_float(buf, 8, voltage_fr);
+    _mav_put_float(buf, 12, voltage_rl);
+    _mav_put_float(buf, 16, voltage_rr);
+    _mav_put_float(buf, 20, current_fl);
+    _mav_put_float(buf, 24, current_fr);
+    _mav_put_float(buf, 28, current_rl);
+    _mav_put_float(buf, 32, current_rr);
+    _mav_put_int32_t(buf, 36, rpm_fl);
+    _mav_put_int32_t(buf, 40, rpm_fr);
+    _mav_put_int32_t(buf, 44, rpm_rl);
+    _mav_put_int32_t(buf, 48, rpm_rr);
+    _mav_put_int32_t(buf, 52, motor_temper_fl);
+    _mav_put_int32_t(buf, 56, motor_temper_fr);
+    _mav_put_int32_t(buf, 60, motor_temper_rl);
+    _mav_put_int32_t(buf, 64, motor_temper_rr);
+    _mav_put_int32_t(buf, 68, esc_temper_fl);
+    _mav_put_int32_t(buf, 72, esc_temper_fr);
+    _mav_put_int32_t(buf, 76, esc_temper_rl);
+    _mav_put_int32_t(buf, 80, esc_temper_rr);
+    _mav_put_float(buf, 84, output_pwm_fl);
+    _mav_put_float(buf, 88, output_pwm_fr);
+    _mav_put_float(buf, 92, output_pwm_rl);
+    _mav_put_float(buf, 96, output_pwm_rr);
+    _mav_put_float(buf, 100, input_pwm_fl);
+    _mav_put_float(buf, 104, input_pwm_fr);
+    _mav_put_float(buf, 108, input_pwm_rl);
+    _mav_put_float(buf, 112, input_pwm_rr);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN);
+#else
+    mavlink_esc_hbci_monitor_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.voltage_fl = voltage_fl;
+    packet.voltage_fr = voltage_fr;
+    packet.voltage_rl = voltage_rl;
+    packet.voltage_rr = voltage_rr;
+    packet.current_fl = current_fl;
+    packet.current_fr = current_fr;
+    packet.current_rl = current_rl;
+    packet.current_rr = current_rr;
+    packet.rpm_fl = rpm_fl;
+    packet.rpm_fr = rpm_fr;
+    packet.rpm_rl = rpm_rl;
+    packet.rpm_rr = rpm_rr;
+    packet.motor_temper_fl = motor_temper_fl;
+    packet.motor_temper_fr = motor_temper_fr;
+    packet.motor_temper_rl = motor_temper_rl;
+    packet.motor_temper_rr = motor_temper_rr;
+    packet.esc_temper_fl = esc_temper_fl;
+    packet.esc_temper_fr = esc_temper_fr;
+    packet.esc_temper_rl = esc_temper_rl;
+    packet.esc_temper_rr = esc_temper_rr;
+    packet.output_pwm_fl = output_pwm_fl;
+    packet.output_pwm_fr = output_pwm_fr;
+    packet.output_pwm_rl = output_pwm_rl;
+    packet.output_pwm_rr = output_pwm_rr;
+    packet.input_pwm_fl = input_pwm_fl;
+    packet.input_pwm_fr = input_pwm_fr;
+    packet.input_pwm_rl = input_pwm_rl;
+    packet.input_pwm_rr = input_pwm_rr;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_ESC_HBCI_MONITOR;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_MIN_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_CRC);
+}
+
+/**
+ * @brief Encode a esc_hbci_monitor struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param esc_hbci_monitor C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_esc_hbci_monitor_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_esc_hbci_monitor_t* esc_hbci_monitor)
+{
+    return mavlink_msg_esc_hbci_monitor_pack(system_id, component_id, msg, esc_hbci_monitor->time_boot_ms, esc_hbci_monitor->voltage_fl, esc_hbci_monitor->voltage_fr, esc_hbci_monitor->voltage_rl, esc_hbci_monitor->voltage_rr, esc_hbci_monitor->current_fl, esc_hbci_monitor->current_fr, esc_hbci_monitor->current_rl, esc_hbci_monitor->current_rr, esc_hbci_monitor->rpm_fl, esc_hbci_monitor->rpm_fr, esc_hbci_monitor->rpm_rl, esc_hbci_monitor->rpm_rr, esc_hbci_monitor->motor_temper_fl, esc_hbci_monitor->motor_temper_fr, esc_hbci_monitor->motor_temper_rl, esc_hbci_monitor->motor_temper_rr, esc_hbci_monitor->esc_temper_fl, esc_hbci_monitor->esc_temper_fr, esc_hbci_monitor->esc_temper_rl, esc_hbci_monitor->esc_temper_rr, esc_hbci_monitor->output_pwm_fl, esc_hbci_monitor->output_pwm_fr, esc_hbci_monitor->output_pwm_rl, esc_hbci_monitor->output_pwm_rr, esc_hbci_monitor->input_pwm_fl, esc_hbci_monitor->input_pwm_fr, esc_hbci_monitor->input_pwm_rl, esc_hbci_monitor->input_pwm_rr);
+}
+
+/**
+ * @brief Encode a esc_hbci_monitor struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param esc_hbci_monitor C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_esc_hbci_monitor_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_esc_hbci_monitor_t* esc_hbci_monitor)
+{
+    return mavlink_msg_esc_hbci_monitor_pack_chan(system_id, component_id, chan, msg, esc_hbci_monitor->time_boot_ms, esc_hbci_monitor->voltage_fl, esc_hbci_monitor->voltage_fr, esc_hbci_monitor->voltage_rl, esc_hbci_monitor->voltage_rr, esc_hbci_monitor->current_fl, esc_hbci_monitor->current_fr, esc_hbci_monitor->current_rl, esc_hbci_monitor->current_rr, esc_hbci_monitor->rpm_fl, esc_hbci_monitor->rpm_fr, esc_hbci_monitor->rpm_rl, esc_hbci_monitor->rpm_rr, esc_hbci_monitor->motor_temper_fl, esc_hbci_monitor->motor_temper_fr, esc_hbci_monitor->motor_temper_rl, esc_hbci_monitor->motor_temper_rr, esc_hbci_monitor->esc_temper_fl, esc_hbci_monitor->esc_temper_fr, esc_hbci_monitor->esc_temper_rl, esc_hbci_monitor->esc_temper_rr, esc_hbci_monitor->output_pwm_fl, esc_hbci_monitor->output_pwm_fr, esc_hbci_monitor->output_pwm_rl, esc_hbci_monitor->output_pwm_rr, esc_hbci_monitor->input_pwm_fl, esc_hbci_monitor->input_pwm_fr, esc_hbci_monitor->input_pwm_rl, esc_hbci_monitor->input_pwm_rr);
+}
+
+/**
+ * @brief Encode a esc_hbci_monitor struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param esc_hbci_monitor C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_esc_hbci_monitor_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_esc_hbci_monitor_t* esc_hbci_monitor)
+{
+    return mavlink_msg_esc_hbci_monitor_pack_status(system_id, component_id, _status, msg,  esc_hbci_monitor->time_boot_ms, esc_hbci_monitor->voltage_fl, esc_hbci_monitor->voltage_fr, esc_hbci_monitor->voltage_rl, esc_hbci_monitor->voltage_rr, esc_hbci_monitor->current_fl, esc_hbci_monitor->current_fr, esc_hbci_monitor->current_rl, esc_hbci_monitor->current_rr, esc_hbci_monitor->rpm_fl, esc_hbci_monitor->rpm_fr, esc_hbci_monitor->rpm_rl, esc_hbci_monitor->rpm_rr, esc_hbci_monitor->motor_temper_fl, esc_hbci_monitor->motor_temper_fr, esc_hbci_monitor->motor_temper_rl, esc_hbci_monitor->motor_temper_rr, esc_hbci_monitor->esc_temper_fl, esc_hbci_monitor->esc_temper_fr, esc_hbci_monitor->esc_temper_rl, esc_hbci_monitor->esc_temper_rr, esc_hbci_monitor->output_pwm_fl, esc_hbci_monitor->output_pwm_fr, esc_hbci_monitor->output_pwm_rl, esc_hbci_monitor->output_pwm_rr, esc_hbci_monitor->input_pwm_fl, esc_hbci_monitor->input_pwm_fr, esc_hbci_monitor->input_pwm_rl, esc_hbci_monitor->input_pwm_rr);
+}
+
+/**
+ * @brief Send a esc_hbci_monitor message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param voltage_fl [V] Front left voltage
+ * @param voltage_fr [V] Front right voltage
+ * @param voltage_rl [V] Rear left voltage
+ * @param voltage_rr [V] Rear right voltage
+ * @param current_fl [A] Front left current
+ * @param current_fr [A] Front right current
+ * @param current_rl [A] Rear left current
+ * @param current_rr [A] Rear right current
+ * @param rpm_fl [RPM] Front left RPM
+ * @param rpm_fr [RPM] Front right RPM
+ * @param rpm_rl [RPM] Rear left RPM
+ * @param rpm_rr [RPM] Rear right RPM
+ * @param motor_temper_fl [degC] Front left motor temperature
+ * @param motor_temper_fr [degC] Front right motor temperature
+ * @param motor_temper_rl [degC] Rear left motor temperature
+ * @param motor_temper_rr [degC] Rear right motor temperature
+ * @param esc_temper_fl [degC] Front left ESC temperature
+ * @param esc_temper_fr [degC] Front right ESC temperature
+ * @param esc_temper_rl [degC] Rear left ESC temperature
+ * @param esc_temper_rr [degC] Rear right ESC temperature
+ * @param output_pwm_fl [%] Front left output PWM
+ * @param output_pwm_fr [%] Front right output PWM
+ * @param output_pwm_rl [%] Rear left output PWM
+ * @param output_pwm_rr [%] Rear right output PWM
+ * @param input_pwm_fl [%] Front left input PWM
+ * @param input_pwm_fr [%] Front right input PWM
+ * @param input_pwm_rl [%] Rear left input PWM
+ * @param input_pwm_rr [%] Rear right input PWM
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_esc_hbci_monitor_send(mavlink_channel_t chan, uint32_t time_boot_ms, float voltage_fl, float voltage_fr, float voltage_rl, float voltage_rr, float current_fl, float current_fr, float current_rl, float current_rr, int32_t rpm_fl, int32_t rpm_fr, int32_t rpm_rl, int32_t rpm_rr, int32_t motor_temper_fl, int32_t motor_temper_fr, int32_t motor_temper_rl, int32_t motor_temper_rr, int32_t esc_temper_fl, int32_t esc_temper_fr, int32_t esc_temper_rl, int32_t esc_temper_rr, float output_pwm_fl, float output_pwm_fr, float output_pwm_rl, float output_pwm_rr, float input_pwm_fl, float input_pwm_fr, float input_pwm_rl, float input_pwm_rr)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, voltage_fl);
+    _mav_put_float(buf, 8, voltage_fr);
+    _mav_put_float(buf, 12, voltage_rl);
+    _mav_put_float(buf, 16, voltage_rr);
+    _mav_put_float(buf, 20, current_fl);
+    _mav_put_float(buf, 24, current_fr);
+    _mav_put_float(buf, 28, current_rl);
+    _mav_put_float(buf, 32, current_rr);
+    _mav_put_int32_t(buf, 36, rpm_fl);
+    _mav_put_int32_t(buf, 40, rpm_fr);
+    _mav_put_int32_t(buf, 44, rpm_rl);
+    _mav_put_int32_t(buf, 48, rpm_rr);
+    _mav_put_int32_t(buf, 52, motor_temper_fl);
+    _mav_put_int32_t(buf, 56, motor_temper_fr);
+    _mav_put_int32_t(buf, 60, motor_temper_rl);
+    _mav_put_int32_t(buf, 64, motor_temper_rr);
+    _mav_put_int32_t(buf, 68, esc_temper_fl);
+    _mav_put_int32_t(buf, 72, esc_temper_fr);
+    _mav_put_int32_t(buf, 76, esc_temper_rl);
+    _mav_put_int32_t(buf, 80, esc_temper_rr);
+    _mav_put_float(buf, 84, output_pwm_fl);
+    _mav_put_float(buf, 88, output_pwm_fr);
+    _mav_put_float(buf, 92, output_pwm_rl);
+    _mav_put_float(buf, 96, output_pwm_rr);
+    _mav_put_float(buf, 100, input_pwm_fl);
+    _mav_put_float(buf, 104, input_pwm_fr);
+    _mav_put_float(buf, 108, input_pwm_rl);
+    _mav_put_float(buf, 112, input_pwm_rr);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_ESC_HBCI_MONITOR, buf, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_MIN_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_CRC);
+#else
+    mavlink_esc_hbci_monitor_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.voltage_fl = voltage_fl;
+    packet.voltage_fr = voltage_fr;
+    packet.voltage_rl = voltage_rl;
+    packet.voltage_rr = voltage_rr;
+    packet.current_fl = current_fl;
+    packet.current_fr = current_fr;
+    packet.current_rl = current_rl;
+    packet.current_rr = current_rr;
+    packet.rpm_fl = rpm_fl;
+    packet.rpm_fr = rpm_fr;
+    packet.rpm_rl = rpm_rl;
+    packet.rpm_rr = rpm_rr;
+    packet.motor_temper_fl = motor_temper_fl;
+    packet.motor_temper_fr = motor_temper_fr;
+    packet.motor_temper_rl = motor_temper_rl;
+    packet.motor_temper_rr = motor_temper_rr;
+    packet.esc_temper_fl = esc_temper_fl;
+    packet.esc_temper_fr = esc_temper_fr;
+    packet.esc_temper_rl = esc_temper_rl;
+    packet.esc_temper_rr = esc_temper_rr;
+    packet.output_pwm_fl = output_pwm_fl;
+    packet.output_pwm_fr = output_pwm_fr;
+    packet.output_pwm_rl = output_pwm_rl;
+    packet.output_pwm_rr = output_pwm_rr;
+    packet.input_pwm_fl = input_pwm_fl;
+    packet.input_pwm_fr = input_pwm_fr;
+    packet.input_pwm_rl = input_pwm_rl;
+    packet.input_pwm_rr = input_pwm_rr;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_ESC_HBCI_MONITOR, (const char *)&packet, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_MIN_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_CRC);
+#endif
+}
+
+/**
+ * @brief Send a esc_hbci_monitor message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_esc_hbci_monitor_send_struct(mavlink_channel_t chan, const mavlink_esc_hbci_monitor_t* esc_hbci_monitor)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_esc_hbci_monitor_send(chan, esc_hbci_monitor->time_boot_ms, esc_hbci_monitor->voltage_fl, esc_hbci_monitor->voltage_fr, esc_hbci_monitor->voltage_rl, esc_hbci_monitor->voltage_rr, esc_hbci_monitor->current_fl, esc_hbci_monitor->current_fr, esc_hbci_monitor->current_rl, esc_hbci_monitor->current_rr, esc_hbci_monitor->rpm_fl, esc_hbci_monitor->rpm_fr, esc_hbci_monitor->rpm_rl, esc_hbci_monitor->rpm_rr, esc_hbci_monitor->motor_temper_fl, esc_hbci_monitor->motor_temper_fr, esc_hbci_monitor->motor_temper_rl, esc_hbci_monitor->motor_temper_rr, esc_hbci_monitor->esc_temper_fl, esc_hbci_monitor->esc_temper_fr, esc_hbci_monitor->esc_temper_rl, esc_hbci_monitor->esc_temper_rr, esc_hbci_monitor->output_pwm_fl, esc_hbci_monitor->output_pwm_fr, esc_hbci_monitor->output_pwm_rl, esc_hbci_monitor->output_pwm_rr, esc_hbci_monitor->input_pwm_fl, esc_hbci_monitor->input_pwm_fr, esc_hbci_monitor->input_pwm_rl, esc_hbci_monitor->input_pwm_rr);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_ESC_HBCI_MONITOR, (const char *)esc_hbci_monitor, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_MIN_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_esc_hbci_monitor_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint32_t time_boot_ms, float voltage_fl, float voltage_fr, float voltage_rl, float voltage_rr, float current_fl, float current_fr, float current_rl, float current_rr, int32_t rpm_fl, int32_t rpm_fr, int32_t rpm_rl, int32_t rpm_rr, int32_t motor_temper_fl, int32_t motor_temper_fr, int32_t motor_temper_rl, int32_t motor_temper_rr, int32_t esc_temper_fl, int32_t esc_temper_fr, int32_t esc_temper_rl, int32_t esc_temper_rr, float output_pwm_fl, float output_pwm_fr, float output_pwm_rl, float output_pwm_rr, float input_pwm_fl, float input_pwm_fr, float input_pwm_rl, float input_pwm_rr)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, voltage_fl);
+    _mav_put_float(buf, 8, voltage_fr);
+    _mav_put_float(buf, 12, voltage_rl);
+    _mav_put_float(buf, 16, voltage_rr);
+    _mav_put_float(buf, 20, current_fl);
+    _mav_put_float(buf, 24, current_fr);
+    _mav_put_float(buf, 28, current_rl);
+    _mav_put_float(buf, 32, current_rr);
+    _mav_put_int32_t(buf, 36, rpm_fl);
+    _mav_put_int32_t(buf, 40, rpm_fr);
+    _mav_put_int32_t(buf, 44, rpm_rl);
+    _mav_put_int32_t(buf, 48, rpm_rr);
+    _mav_put_int32_t(buf, 52, motor_temper_fl);
+    _mav_put_int32_t(buf, 56, motor_temper_fr);
+    _mav_put_int32_t(buf, 60, motor_temper_rl);
+    _mav_put_int32_t(buf, 64, motor_temper_rr);
+    _mav_put_int32_t(buf, 68, esc_temper_fl);
+    _mav_put_int32_t(buf, 72, esc_temper_fr);
+    _mav_put_int32_t(buf, 76, esc_temper_rl);
+    _mav_put_int32_t(buf, 80, esc_temper_rr);
+    _mav_put_float(buf, 84, output_pwm_fl);
+    _mav_put_float(buf, 88, output_pwm_fr);
+    _mav_put_float(buf, 92, output_pwm_rl);
+    _mav_put_float(buf, 96, output_pwm_rr);
+    _mav_put_float(buf, 100, input_pwm_fl);
+    _mav_put_float(buf, 104, input_pwm_fr);
+    _mav_put_float(buf, 108, input_pwm_rl);
+    _mav_put_float(buf, 112, input_pwm_rr);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_ESC_HBCI_MONITOR, buf, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_MIN_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_CRC);
+#else
+    mavlink_esc_hbci_monitor_t *packet = (mavlink_esc_hbci_monitor_t *)msgbuf;
+    packet->time_boot_ms = time_boot_ms;
+    packet->voltage_fl = voltage_fl;
+    packet->voltage_fr = voltage_fr;
+    packet->voltage_rl = voltage_rl;
+    packet->voltage_rr = voltage_rr;
+    packet->current_fl = current_fl;
+    packet->current_fr = current_fr;
+    packet->current_rl = current_rl;
+    packet->current_rr = current_rr;
+    packet->rpm_fl = rpm_fl;
+    packet->rpm_fr = rpm_fr;
+    packet->rpm_rl = rpm_rl;
+    packet->rpm_rr = rpm_rr;
+    packet->motor_temper_fl = motor_temper_fl;
+    packet->motor_temper_fr = motor_temper_fr;
+    packet->motor_temper_rl = motor_temper_rl;
+    packet->motor_temper_rr = motor_temper_rr;
+    packet->esc_temper_fl = esc_temper_fl;
+    packet->esc_temper_fr = esc_temper_fr;
+    packet->esc_temper_rl = esc_temper_rl;
+    packet->esc_temper_rr = esc_temper_rr;
+    packet->output_pwm_fl = output_pwm_fl;
+    packet->output_pwm_fr = output_pwm_fr;
+    packet->output_pwm_rl = output_pwm_rl;
+    packet->output_pwm_rr = output_pwm_rr;
+    packet->input_pwm_fl = input_pwm_fl;
+    packet->input_pwm_fr = input_pwm_fr;
+    packet->input_pwm_rl = input_pwm_rl;
+    packet->input_pwm_rr = input_pwm_rr;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_ESC_HBCI_MONITOR, (const char *)packet, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_MIN_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE ESC_HBCI_MONITOR UNPACKING
+
+
+/**
+ * @brief Get field time_boot_ms from esc_hbci_monitor message
+ *
+ * @return [ms] Timestamp (time since system boot).
+ */
+static inline uint32_t mavlink_msg_esc_hbci_monitor_get_time_boot_ms(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  0);
+}
+
+/**
+ * @brief Get field voltage_fl from esc_hbci_monitor message
+ *
+ * @return [V] Front left voltage
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_voltage_fl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  4);
+}
+
+/**
+ * @brief Get field voltage_fr from esc_hbci_monitor message
+ *
+ * @return [V] Front right voltage
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_voltage_fr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  8);
+}
+
+/**
+ * @brief Get field voltage_rl from esc_hbci_monitor message
+ *
+ * @return [V] Rear left voltage
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_voltage_rl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  12);
+}
+
+/**
+ * @brief Get field voltage_rr from esc_hbci_monitor message
+ *
+ * @return [V] Rear right voltage
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_voltage_rr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  16);
+}
+
+/**
+ * @brief Get field current_fl from esc_hbci_monitor message
+ *
+ * @return [A] Front left current
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_current_fl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  20);
+}
+
+/**
+ * @brief Get field current_fr from esc_hbci_monitor message
+ *
+ * @return [A] Front right current
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_current_fr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  24);
+}
+
+/**
+ * @brief Get field current_rl from esc_hbci_monitor message
+ *
+ * @return [A] Rear left current
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_current_rl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  28);
+}
+
+/**
+ * @brief Get field current_rr from esc_hbci_monitor message
+ *
+ * @return [A] Rear right current
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_current_rr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  32);
+}
+
+/**
+ * @brief Get field rpm_fl from esc_hbci_monitor message
+ *
+ * @return [RPM] Front left RPM
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_rpm_fl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  36);
+}
+
+/**
+ * @brief Get field rpm_fr from esc_hbci_monitor message
+ *
+ * @return [RPM] Front right RPM
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_rpm_fr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  40);
+}
+
+/**
+ * @brief Get field rpm_rl from esc_hbci_monitor message
+ *
+ * @return [RPM] Rear left RPM
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_rpm_rl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  44);
+}
+
+/**
+ * @brief Get field rpm_rr from esc_hbci_monitor message
+ *
+ * @return [RPM] Rear right RPM
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_rpm_rr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  48);
+}
+
+/**
+ * @brief Get field motor_temper_fl from esc_hbci_monitor message
+ *
+ * @return [degC] Front left motor temperature
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_motor_temper_fl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  52);
+}
+
+/**
+ * @brief Get field motor_temper_fr from esc_hbci_monitor message
+ *
+ * @return [degC] Front right motor temperature
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_motor_temper_fr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  56);
+}
+
+/**
+ * @brief Get field motor_temper_rl from esc_hbci_monitor message
+ *
+ * @return [degC] Rear left motor temperature
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_motor_temper_rl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  60);
+}
+
+/**
+ * @brief Get field motor_temper_rr from esc_hbci_monitor message
+ *
+ * @return [degC] Rear right motor temperature
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_motor_temper_rr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  64);
+}
+
+/**
+ * @brief Get field esc_temper_fl from esc_hbci_monitor message
+ *
+ * @return [degC] Front left ESC temperature
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_esc_temper_fl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  68);
+}
+
+/**
+ * @brief Get field esc_temper_fr from esc_hbci_monitor message
+ *
+ * @return [degC] Front right ESC temperature
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_esc_temper_fr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  72);
+}
+
+/**
+ * @brief Get field esc_temper_rl from esc_hbci_monitor message
+ *
+ * @return [degC] Rear left ESC temperature
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_esc_temper_rl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  76);
+}
+
+/**
+ * @brief Get field esc_temper_rr from esc_hbci_monitor message
+ *
+ * @return [degC] Rear right ESC temperature
+ */
+static inline int32_t mavlink_msg_esc_hbci_monitor_get_esc_temper_rr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  80);
+}
+
+/**
+ * @brief Get field output_pwm_fl from esc_hbci_monitor message
+ *
+ * @return [%] Front left output PWM
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_output_pwm_fl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  84);
+}
+
+/**
+ * @brief Get field output_pwm_fr from esc_hbci_monitor message
+ *
+ * @return [%] Front right output PWM
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_output_pwm_fr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  88);
+}
+
+/**
+ * @brief Get field output_pwm_rl from esc_hbci_monitor message
+ *
+ * @return [%] Rear left output PWM
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_output_pwm_rl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  92);
+}
+
+/**
+ * @brief Get field output_pwm_rr from esc_hbci_monitor message
+ *
+ * @return [%] Rear right output PWM
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_output_pwm_rr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  96);
+}
+
+/**
+ * @brief Get field input_pwm_fl from esc_hbci_monitor message
+ *
+ * @return [%] Front left input PWM
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_input_pwm_fl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  100);
+}
+
+/**
+ * @brief Get field input_pwm_fr from esc_hbci_monitor message
+ *
+ * @return [%] Front right input PWM
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_input_pwm_fr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  104);
+}
+
+/**
+ * @brief Get field input_pwm_rl from esc_hbci_monitor message
+ *
+ * @return [%] Rear left input PWM
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_input_pwm_rl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  108);
+}
+
+/**
+ * @brief Get field input_pwm_rr from esc_hbci_monitor message
+ *
+ * @return [%] Rear right input PWM
+ */
+static inline float mavlink_msg_esc_hbci_monitor_get_input_pwm_rr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  112);
+}
+
+/**
+ * @brief Decode a esc_hbci_monitor message into a struct
+ *
+ * @param msg The message to decode
+ * @param esc_hbci_monitor C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_esc_hbci_monitor_decode(const mavlink_message_t* msg, mavlink_esc_hbci_monitor_t* esc_hbci_monitor)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    esc_hbci_monitor->time_boot_ms = mavlink_msg_esc_hbci_monitor_get_time_boot_ms(msg);
+    esc_hbci_monitor->voltage_fl = mavlink_msg_esc_hbci_monitor_get_voltage_fl(msg);
+    esc_hbci_monitor->voltage_fr = mavlink_msg_esc_hbci_monitor_get_voltage_fr(msg);
+    esc_hbci_monitor->voltage_rl = mavlink_msg_esc_hbci_monitor_get_voltage_rl(msg);
+    esc_hbci_monitor->voltage_rr = mavlink_msg_esc_hbci_monitor_get_voltage_rr(msg);
+    esc_hbci_monitor->current_fl = mavlink_msg_esc_hbci_monitor_get_current_fl(msg);
+    esc_hbci_monitor->current_fr = mavlink_msg_esc_hbci_monitor_get_current_fr(msg);
+    esc_hbci_monitor->current_rl = mavlink_msg_esc_hbci_monitor_get_current_rl(msg);
+    esc_hbci_monitor->current_rr = mavlink_msg_esc_hbci_monitor_get_current_rr(msg);
+    esc_hbci_monitor->rpm_fl = mavlink_msg_esc_hbci_monitor_get_rpm_fl(msg);
+    esc_hbci_monitor->rpm_fr = mavlink_msg_esc_hbci_monitor_get_rpm_fr(msg);
+    esc_hbci_monitor->rpm_rl = mavlink_msg_esc_hbci_monitor_get_rpm_rl(msg);
+    esc_hbci_monitor->rpm_rr = mavlink_msg_esc_hbci_monitor_get_rpm_rr(msg);
+    esc_hbci_monitor->motor_temper_fl = mavlink_msg_esc_hbci_monitor_get_motor_temper_fl(msg);
+    esc_hbci_monitor->motor_temper_fr = mavlink_msg_esc_hbci_monitor_get_motor_temper_fr(msg);
+    esc_hbci_monitor->motor_temper_rl = mavlink_msg_esc_hbci_monitor_get_motor_temper_rl(msg);
+    esc_hbci_monitor->motor_temper_rr = mavlink_msg_esc_hbci_monitor_get_motor_temper_rr(msg);
+    esc_hbci_monitor->esc_temper_fl = mavlink_msg_esc_hbci_monitor_get_esc_temper_fl(msg);
+    esc_hbci_monitor->esc_temper_fr = mavlink_msg_esc_hbci_monitor_get_esc_temper_fr(msg);
+    esc_hbci_monitor->esc_temper_rl = mavlink_msg_esc_hbci_monitor_get_esc_temper_rl(msg);
+    esc_hbci_monitor->esc_temper_rr = mavlink_msg_esc_hbci_monitor_get_esc_temper_rr(msg);
+    esc_hbci_monitor->output_pwm_fl = mavlink_msg_esc_hbci_monitor_get_output_pwm_fl(msg);
+    esc_hbci_monitor->output_pwm_fr = mavlink_msg_esc_hbci_monitor_get_output_pwm_fr(msg);
+    esc_hbci_monitor->output_pwm_rl = mavlink_msg_esc_hbci_monitor_get_output_pwm_rl(msg);
+    esc_hbci_monitor->output_pwm_rr = mavlink_msg_esc_hbci_monitor_get_output_pwm_rr(msg);
+    esc_hbci_monitor->input_pwm_fl = mavlink_msg_esc_hbci_monitor_get_input_pwm_fl(msg);
+    esc_hbci_monitor->input_pwm_fr = mavlink_msg_esc_hbci_monitor_get_input_pwm_fr(msg);
+    esc_hbci_monitor->input_pwm_rl = mavlink_msg_esc_hbci_monitor_get_input_pwm_rl(msg);
+    esc_hbci_monitor->input_pwm_rr = mavlink_msg_esc_hbci_monitor_get_input_pwm_rr(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN? msg->len : MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN;
+        memset(esc_hbci_monitor, 0, MAVLINK_MSG_ID_ESC_HBCI_MONITOR_LEN);
+    memcpy(esc_hbci_monitor, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_figure_eight_execution_status.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_figure_eight_execution_status.h
@@ -1,0 +1,456 @@
+#pragma once
+// MESSAGE FIGURE_EIGHT_EXECUTION_STATUS PACKING
+
+#define MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS 361
+
+
+typedef struct __mavlink_figure_eight_execution_status_t {
+ uint64_t time_usec; /*< [us] Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.*/
+ float major_radius; /*< [m] Major axis radius of the figure eight. Positive: orbit the north circle clockwise. Negative: orbit the north circle counter-clockwise.*/
+ float minor_radius; /*< [m] Minor axis radius of the figure eight. Defines the radius of two circles that make up the figure.*/
+ float orientation; /*< [rad] Orientation of the figure eight major axis with respect to true north in [-pi,pi).*/
+ int32_t x; /*<  X coordinate of center point. Coordinate system depends on frame field.*/
+ int32_t y; /*<  Y coordinate of center point. Coordinate system depends on frame field.*/
+ float z; /*< [m] Altitude of center point. Coordinate system depends on frame field.*/
+ uint8_t frame; /*<  The coordinate system of the fields: x, y, z.*/
+} mavlink_figure_eight_execution_status_t;
+
+#define MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN 33
+#define MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_MIN_LEN 33
+#define MAVLINK_MSG_ID_361_LEN 33
+#define MAVLINK_MSG_ID_361_MIN_LEN 33
+
+#define MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_CRC 93
+#define MAVLINK_MSG_ID_361_CRC 93
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_FIGURE_EIGHT_EXECUTION_STATUS { \
+    361, \
+    "FIGURE_EIGHT_EXECUTION_STATUS", \
+    8, \
+    {  { "time_usec", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_figure_eight_execution_status_t, time_usec) }, \
+         { "major_radius", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_figure_eight_execution_status_t, major_radius) }, \
+         { "minor_radius", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_figure_eight_execution_status_t, minor_radius) }, \
+         { "orientation", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_figure_eight_execution_status_t, orientation) }, \
+         { "frame", NULL, MAVLINK_TYPE_UINT8_T, 0, 32, offsetof(mavlink_figure_eight_execution_status_t, frame) }, \
+         { "x", NULL, MAVLINK_TYPE_INT32_T, 0, 20, offsetof(mavlink_figure_eight_execution_status_t, x) }, \
+         { "y", NULL, MAVLINK_TYPE_INT32_T, 0, 24, offsetof(mavlink_figure_eight_execution_status_t, y) }, \
+         { "z", NULL, MAVLINK_TYPE_FLOAT, 0, 28, offsetof(mavlink_figure_eight_execution_status_t, z) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_FIGURE_EIGHT_EXECUTION_STATUS { \
+    "FIGURE_EIGHT_EXECUTION_STATUS", \
+    8, \
+    {  { "time_usec", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_figure_eight_execution_status_t, time_usec) }, \
+         { "major_radius", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_figure_eight_execution_status_t, major_radius) }, \
+         { "minor_radius", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_figure_eight_execution_status_t, minor_radius) }, \
+         { "orientation", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_figure_eight_execution_status_t, orientation) }, \
+         { "frame", NULL, MAVLINK_TYPE_UINT8_T, 0, 32, offsetof(mavlink_figure_eight_execution_status_t, frame) }, \
+         { "x", NULL, MAVLINK_TYPE_INT32_T, 0, 20, offsetof(mavlink_figure_eight_execution_status_t, x) }, \
+         { "y", NULL, MAVLINK_TYPE_INT32_T, 0, 24, offsetof(mavlink_figure_eight_execution_status_t, y) }, \
+         { "z", NULL, MAVLINK_TYPE_FLOAT, 0, 28, offsetof(mavlink_figure_eight_execution_status_t, z) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a figure_eight_execution_status message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ * @param major_radius [m] Major axis radius of the figure eight. Positive: orbit the north circle clockwise. Negative: orbit the north circle counter-clockwise.
+ * @param minor_radius [m] Minor axis radius of the figure eight. Defines the radius of two circles that make up the figure.
+ * @param orientation [rad] Orientation of the figure eight major axis with respect to true north in [-pi,pi).
+ * @param frame  The coordinate system of the fields: x, y, z.
+ * @param x  X coordinate of center point. Coordinate system depends on frame field.
+ * @param y  Y coordinate of center point. Coordinate system depends on frame field.
+ * @param z [m] Altitude of center point. Coordinate system depends on frame field.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_figure_eight_execution_status_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint64_t time_usec, float major_radius, float minor_radius, float orientation, uint8_t frame, int32_t x, int32_t y, float z)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_float(buf, 8, major_radius);
+    _mav_put_float(buf, 12, minor_radius);
+    _mav_put_float(buf, 16, orientation);
+    _mav_put_int32_t(buf, 20, x);
+    _mav_put_int32_t(buf, 24, y);
+    _mav_put_float(buf, 28, z);
+    _mav_put_uint8_t(buf, 32, frame);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN);
+#else
+    mavlink_figure_eight_execution_status_t packet;
+    packet.time_usec = time_usec;
+    packet.major_radius = major_radius;
+    packet.minor_radius = minor_radius;
+    packet.orientation = orientation;
+    packet.x = x;
+    packet.y = y;
+    packet.z = z;
+    packet.frame = frame;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_MIN_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_CRC);
+}
+
+/**
+ * @brief Pack a figure_eight_execution_status message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ * @param major_radius [m] Major axis radius of the figure eight. Positive: orbit the north circle clockwise. Negative: orbit the north circle counter-clockwise.
+ * @param minor_radius [m] Minor axis radius of the figure eight. Defines the radius of two circles that make up the figure.
+ * @param orientation [rad] Orientation of the figure eight major axis with respect to true north in [-pi,pi).
+ * @param frame  The coordinate system of the fields: x, y, z.
+ * @param x  X coordinate of center point. Coordinate system depends on frame field.
+ * @param y  Y coordinate of center point. Coordinate system depends on frame field.
+ * @param z [m] Altitude of center point. Coordinate system depends on frame field.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_figure_eight_execution_status_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint64_t time_usec, float major_radius, float minor_radius, float orientation, uint8_t frame, int32_t x, int32_t y, float z)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_float(buf, 8, major_radius);
+    _mav_put_float(buf, 12, minor_radius);
+    _mav_put_float(buf, 16, orientation);
+    _mav_put_int32_t(buf, 20, x);
+    _mav_put_int32_t(buf, 24, y);
+    _mav_put_float(buf, 28, z);
+    _mav_put_uint8_t(buf, 32, frame);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN);
+#else
+    mavlink_figure_eight_execution_status_t packet;
+    packet.time_usec = time_usec;
+    packet.major_radius = major_radius;
+    packet.minor_radius = minor_radius;
+    packet.orientation = orientation;
+    packet.x = x;
+    packet.y = y;
+    packet.z = z;
+    packet.frame = frame;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_MIN_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_MIN_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a figure_eight_execution_status message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ * @param major_radius [m] Major axis radius of the figure eight. Positive: orbit the north circle clockwise. Negative: orbit the north circle counter-clockwise.
+ * @param minor_radius [m] Minor axis radius of the figure eight. Defines the radius of two circles that make up the figure.
+ * @param orientation [rad] Orientation of the figure eight major axis with respect to true north in [-pi,pi).
+ * @param frame  The coordinate system of the fields: x, y, z.
+ * @param x  X coordinate of center point. Coordinate system depends on frame field.
+ * @param y  Y coordinate of center point. Coordinate system depends on frame field.
+ * @param z [m] Altitude of center point. Coordinate system depends on frame field.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_figure_eight_execution_status_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint64_t time_usec,float major_radius,float minor_radius,float orientation,uint8_t frame,int32_t x,int32_t y,float z)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_float(buf, 8, major_radius);
+    _mav_put_float(buf, 12, minor_radius);
+    _mav_put_float(buf, 16, orientation);
+    _mav_put_int32_t(buf, 20, x);
+    _mav_put_int32_t(buf, 24, y);
+    _mav_put_float(buf, 28, z);
+    _mav_put_uint8_t(buf, 32, frame);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN);
+#else
+    mavlink_figure_eight_execution_status_t packet;
+    packet.time_usec = time_usec;
+    packet.major_radius = major_radius;
+    packet.minor_radius = minor_radius;
+    packet.orientation = orientation;
+    packet.x = x;
+    packet.y = y;
+    packet.z = z;
+    packet.frame = frame;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_MIN_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_CRC);
+}
+
+/**
+ * @brief Encode a figure_eight_execution_status struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param figure_eight_execution_status C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_figure_eight_execution_status_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_figure_eight_execution_status_t* figure_eight_execution_status)
+{
+    return mavlink_msg_figure_eight_execution_status_pack(system_id, component_id, msg, figure_eight_execution_status->time_usec, figure_eight_execution_status->major_radius, figure_eight_execution_status->minor_radius, figure_eight_execution_status->orientation, figure_eight_execution_status->frame, figure_eight_execution_status->x, figure_eight_execution_status->y, figure_eight_execution_status->z);
+}
+
+/**
+ * @brief Encode a figure_eight_execution_status struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param figure_eight_execution_status C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_figure_eight_execution_status_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_figure_eight_execution_status_t* figure_eight_execution_status)
+{
+    return mavlink_msg_figure_eight_execution_status_pack_chan(system_id, component_id, chan, msg, figure_eight_execution_status->time_usec, figure_eight_execution_status->major_radius, figure_eight_execution_status->minor_radius, figure_eight_execution_status->orientation, figure_eight_execution_status->frame, figure_eight_execution_status->x, figure_eight_execution_status->y, figure_eight_execution_status->z);
+}
+
+/**
+ * @brief Encode a figure_eight_execution_status struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param figure_eight_execution_status C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_figure_eight_execution_status_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_figure_eight_execution_status_t* figure_eight_execution_status)
+{
+    return mavlink_msg_figure_eight_execution_status_pack_status(system_id, component_id, _status, msg,  figure_eight_execution_status->time_usec, figure_eight_execution_status->major_radius, figure_eight_execution_status->minor_radius, figure_eight_execution_status->orientation, figure_eight_execution_status->frame, figure_eight_execution_status->x, figure_eight_execution_status->y, figure_eight_execution_status->z);
+}
+
+/**
+ * @brief Send a figure_eight_execution_status message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ * @param major_radius [m] Major axis radius of the figure eight. Positive: orbit the north circle clockwise. Negative: orbit the north circle counter-clockwise.
+ * @param minor_radius [m] Minor axis radius of the figure eight. Defines the radius of two circles that make up the figure.
+ * @param orientation [rad] Orientation of the figure eight major axis with respect to true north in [-pi,pi).
+ * @param frame  The coordinate system of the fields: x, y, z.
+ * @param x  X coordinate of center point. Coordinate system depends on frame field.
+ * @param y  Y coordinate of center point. Coordinate system depends on frame field.
+ * @param z [m] Altitude of center point. Coordinate system depends on frame field.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_figure_eight_execution_status_send(mavlink_channel_t chan, uint64_t time_usec, float major_radius, float minor_radius, float orientation, uint8_t frame, int32_t x, int32_t y, float z)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_float(buf, 8, major_radius);
+    _mav_put_float(buf, 12, minor_radius);
+    _mav_put_float(buf, 16, orientation);
+    _mav_put_int32_t(buf, 20, x);
+    _mav_put_int32_t(buf, 24, y);
+    _mav_put_float(buf, 28, z);
+    _mav_put_uint8_t(buf, 32, frame);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS, buf, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_MIN_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_CRC);
+#else
+    mavlink_figure_eight_execution_status_t packet;
+    packet.time_usec = time_usec;
+    packet.major_radius = major_radius;
+    packet.minor_radius = minor_radius;
+    packet.orientation = orientation;
+    packet.x = x;
+    packet.y = y;
+    packet.z = z;
+    packet.frame = frame;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS, (const char *)&packet, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_MIN_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_CRC);
+#endif
+}
+
+/**
+ * @brief Send a figure_eight_execution_status message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_figure_eight_execution_status_send_struct(mavlink_channel_t chan, const mavlink_figure_eight_execution_status_t* figure_eight_execution_status)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_figure_eight_execution_status_send(chan, figure_eight_execution_status->time_usec, figure_eight_execution_status->major_radius, figure_eight_execution_status->minor_radius, figure_eight_execution_status->orientation, figure_eight_execution_status->frame, figure_eight_execution_status->x, figure_eight_execution_status->y, figure_eight_execution_status->z);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS, (const char *)figure_eight_execution_status, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_MIN_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_figure_eight_execution_status_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint64_t time_usec, float major_radius, float minor_radius, float orientation, uint8_t frame, int32_t x, int32_t y, float z)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_float(buf, 8, major_radius);
+    _mav_put_float(buf, 12, minor_radius);
+    _mav_put_float(buf, 16, orientation);
+    _mav_put_int32_t(buf, 20, x);
+    _mav_put_int32_t(buf, 24, y);
+    _mav_put_float(buf, 28, z);
+    _mav_put_uint8_t(buf, 32, frame);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS, buf, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_MIN_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_CRC);
+#else
+    mavlink_figure_eight_execution_status_t *packet = (mavlink_figure_eight_execution_status_t *)msgbuf;
+    packet->time_usec = time_usec;
+    packet->major_radius = major_radius;
+    packet->minor_radius = minor_radius;
+    packet->orientation = orientation;
+    packet->x = x;
+    packet->y = y;
+    packet->z = z;
+    packet->frame = frame;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS, (const char *)packet, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_MIN_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE FIGURE_EIGHT_EXECUTION_STATUS UNPACKING
+
+
+/**
+ * @brief Get field time_usec from figure_eight_execution_status message
+ *
+ * @return [us] Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ */
+static inline uint64_t mavlink_msg_figure_eight_execution_status_get_time_usec(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint64_t(msg,  0);
+}
+
+/**
+ * @brief Get field major_radius from figure_eight_execution_status message
+ *
+ * @return [m] Major axis radius of the figure eight. Positive: orbit the north circle clockwise. Negative: orbit the north circle counter-clockwise.
+ */
+static inline float mavlink_msg_figure_eight_execution_status_get_major_radius(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  8);
+}
+
+/**
+ * @brief Get field minor_radius from figure_eight_execution_status message
+ *
+ * @return [m] Minor axis radius of the figure eight. Defines the radius of two circles that make up the figure.
+ */
+static inline float mavlink_msg_figure_eight_execution_status_get_minor_radius(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  12);
+}
+
+/**
+ * @brief Get field orientation from figure_eight_execution_status message
+ *
+ * @return [rad] Orientation of the figure eight major axis with respect to true north in [-pi,pi).
+ */
+static inline float mavlink_msg_figure_eight_execution_status_get_orientation(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  16);
+}
+
+/**
+ * @brief Get field frame from figure_eight_execution_status message
+ *
+ * @return  The coordinate system of the fields: x, y, z.
+ */
+static inline uint8_t mavlink_msg_figure_eight_execution_status_get_frame(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  32);
+}
+
+/**
+ * @brief Get field x from figure_eight_execution_status message
+ *
+ * @return  X coordinate of center point. Coordinate system depends on frame field.
+ */
+static inline int32_t mavlink_msg_figure_eight_execution_status_get_x(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  20);
+}
+
+/**
+ * @brief Get field y from figure_eight_execution_status message
+ *
+ * @return  Y coordinate of center point. Coordinate system depends on frame field.
+ */
+static inline int32_t mavlink_msg_figure_eight_execution_status_get_y(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  24);
+}
+
+/**
+ * @brief Get field z from figure_eight_execution_status message
+ *
+ * @return [m] Altitude of center point. Coordinate system depends on frame field.
+ */
+static inline float mavlink_msg_figure_eight_execution_status_get_z(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  28);
+}
+
+/**
+ * @brief Decode a figure_eight_execution_status message into a struct
+ *
+ * @param msg The message to decode
+ * @param figure_eight_execution_status C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_figure_eight_execution_status_decode(const mavlink_message_t* msg, mavlink_figure_eight_execution_status_t* figure_eight_execution_status)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    figure_eight_execution_status->time_usec = mavlink_msg_figure_eight_execution_status_get_time_usec(msg);
+    figure_eight_execution_status->major_radius = mavlink_msg_figure_eight_execution_status_get_major_radius(msg);
+    figure_eight_execution_status->minor_radius = mavlink_msg_figure_eight_execution_status_get_minor_radius(msg);
+    figure_eight_execution_status->orientation = mavlink_msg_figure_eight_execution_status_get_orientation(msg);
+    figure_eight_execution_status->x = mavlink_msg_figure_eight_execution_status_get_x(msg);
+    figure_eight_execution_status->y = mavlink_msg_figure_eight_execution_status_get_y(msg);
+    figure_eight_execution_status->z = mavlink_msg_figure_eight_execution_status_get_z(msg);
+    figure_eight_execution_status->frame = mavlink_msg_figure_eight_execution_status_get_frame(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN? msg->len : MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN;
+        memset(figure_eight_execution_status, 0, MAVLINK_MSG_ID_FIGURE_EIGHT_EXECUTION_STATUS_LEN);
+    memcpy(figure_eight_execution_status, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_group_end.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_group_end.h
@@ -1,0 +1,322 @@
+#pragma once
+// MESSAGE GROUP_END PACKING
+
+#define MAVLINK_MSG_ID_GROUP_END 415
+
+
+typedef struct __mavlink_group_end_t {
+ uint64_t time_usec; /*< [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.*/
+ uint32_t group_id; /*<  Mission-unique group id (from MAV_CMD_GROUP_END).*/
+ uint32_t mission_checksum; /*<  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.*/
+} mavlink_group_end_t;
+
+#define MAVLINK_MSG_ID_GROUP_END_LEN 16
+#define MAVLINK_MSG_ID_GROUP_END_MIN_LEN 16
+#define MAVLINK_MSG_ID_415_LEN 16
+#define MAVLINK_MSG_ID_415_MIN_LEN 16
+
+#define MAVLINK_MSG_ID_GROUP_END_CRC 161
+#define MAVLINK_MSG_ID_415_CRC 161
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_GROUP_END { \
+    415, \
+    "GROUP_END", \
+    3, \
+    {  { "group_id", NULL, MAVLINK_TYPE_UINT32_T, 0, 8, offsetof(mavlink_group_end_t, group_id) }, \
+         { "mission_checksum", NULL, MAVLINK_TYPE_UINT32_T, 0, 12, offsetof(mavlink_group_end_t, mission_checksum) }, \
+         { "time_usec", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_group_end_t, time_usec) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_GROUP_END { \
+    "GROUP_END", \
+    3, \
+    {  { "group_id", NULL, MAVLINK_TYPE_UINT32_T, 0, 8, offsetof(mavlink_group_end_t, group_id) }, \
+         { "mission_checksum", NULL, MAVLINK_TYPE_UINT32_T, 0, 12, offsetof(mavlink_group_end_t, mission_checksum) }, \
+         { "time_usec", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_group_end_t, time_usec) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a group_end message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param group_id  Mission-unique group id (from MAV_CMD_GROUP_END).
+ * @param mission_checksum  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_group_end_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint32_t group_id, uint32_t mission_checksum, uint64_t time_usec)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_GROUP_END_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_uint32_t(buf, 8, group_id);
+    _mav_put_uint32_t(buf, 12, mission_checksum);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_GROUP_END_LEN);
+#else
+    mavlink_group_end_t packet;
+    packet.time_usec = time_usec;
+    packet.group_id = group_id;
+    packet.mission_checksum = mission_checksum;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_GROUP_END_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_GROUP_END;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_GROUP_END_MIN_LEN, MAVLINK_MSG_ID_GROUP_END_LEN, MAVLINK_MSG_ID_GROUP_END_CRC);
+}
+
+/**
+ * @brief Pack a group_end message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param group_id  Mission-unique group id (from MAV_CMD_GROUP_END).
+ * @param mission_checksum  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_group_end_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint32_t group_id, uint32_t mission_checksum, uint64_t time_usec)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_GROUP_END_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_uint32_t(buf, 8, group_id);
+    _mav_put_uint32_t(buf, 12, mission_checksum);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_GROUP_END_LEN);
+#else
+    mavlink_group_end_t packet;
+    packet.time_usec = time_usec;
+    packet.group_id = group_id;
+    packet.mission_checksum = mission_checksum;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_GROUP_END_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_GROUP_END;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_GROUP_END_MIN_LEN, MAVLINK_MSG_ID_GROUP_END_LEN, MAVLINK_MSG_ID_GROUP_END_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_GROUP_END_MIN_LEN, MAVLINK_MSG_ID_GROUP_END_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a group_end message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param group_id  Mission-unique group id (from MAV_CMD_GROUP_END).
+ * @param mission_checksum  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_group_end_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint32_t group_id,uint32_t mission_checksum,uint64_t time_usec)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_GROUP_END_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_uint32_t(buf, 8, group_id);
+    _mav_put_uint32_t(buf, 12, mission_checksum);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_GROUP_END_LEN);
+#else
+    mavlink_group_end_t packet;
+    packet.time_usec = time_usec;
+    packet.group_id = group_id;
+    packet.mission_checksum = mission_checksum;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_GROUP_END_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_GROUP_END;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_GROUP_END_MIN_LEN, MAVLINK_MSG_ID_GROUP_END_LEN, MAVLINK_MSG_ID_GROUP_END_CRC);
+}
+
+/**
+ * @brief Encode a group_end struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param group_end C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_group_end_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_group_end_t* group_end)
+{
+    return mavlink_msg_group_end_pack(system_id, component_id, msg, group_end->group_id, group_end->mission_checksum, group_end->time_usec);
+}
+
+/**
+ * @brief Encode a group_end struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param group_end C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_group_end_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_group_end_t* group_end)
+{
+    return mavlink_msg_group_end_pack_chan(system_id, component_id, chan, msg, group_end->group_id, group_end->mission_checksum, group_end->time_usec);
+}
+
+/**
+ * @brief Encode a group_end struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param group_end C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_group_end_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_group_end_t* group_end)
+{
+    return mavlink_msg_group_end_pack_status(system_id, component_id, _status, msg,  group_end->group_id, group_end->mission_checksum, group_end->time_usec);
+}
+
+/**
+ * @brief Send a group_end message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param group_id  Mission-unique group id (from MAV_CMD_GROUP_END).
+ * @param mission_checksum  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_group_end_send(mavlink_channel_t chan, uint32_t group_id, uint32_t mission_checksum, uint64_t time_usec)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_GROUP_END_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_uint32_t(buf, 8, group_id);
+    _mav_put_uint32_t(buf, 12, mission_checksum);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_GROUP_END, buf, MAVLINK_MSG_ID_GROUP_END_MIN_LEN, MAVLINK_MSG_ID_GROUP_END_LEN, MAVLINK_MSG_ID_GROUP_END_CRC);
+#else
+    mavlink_group_end_t packet;
+    packet.time_usec = time_usec;
+    packet.group_id = group_id;
+    packet.mission_checksum = mission_checksum;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_GROUP_END, (const char *)&packet, MAVLINK_MSG_ID_GROUP_END_MIN_LEN, MAVLINK_MSG_ID_GROUP_END_LEN, MAVLINK_MSG_ID_GROUP_END_CRC);
+#endif
+}
+
+/**
+ * @brief Send a group_end message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_group_end_send_struct(mavlink_channel_t chan, const mavlink_group_end_t* group_end)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_group_end_send(chan, group_end->group_id, group_end->mission_checksum, group_end->time_usec);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_GROUP_END, (const char *)group_end, MAVLINK_MSG_ID_GROUP_END_MIN_LEN, MAVLINK_MSG_ID_GROUP_END_LEN, MAVLINK_MSG_ID_GROUP_END_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_GROUP_END_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_group_end_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint32_t group_id, uint32_t mission_checksum, uint64_t time_usec)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_uint32_t(buf, 8, group_id);
+    _mav_put_uint32_t(buf, 12, mission_checksum);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_GROUP_END, buf, MAVLINK_MSG_ID_GROUP_END_MIN_LEN, MAVLINK_MSG_ID_GROUP_END_LEN, MAVLINK_MSG_ID_GROUP_END_CRC);
+#else
+    mavlink_group_end_t *packet = (mavlink_group_end_t *)msgbuf;
+    packet->time_usec = time_usec;
+    packet->group_id = group_id;
+    packet->mission_checksum = mission_checksum;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_GROUP_END, (const char *)packet, MAVLINK_MSG_ID_GROUP_END_MIN_LEN, MAVLINK_MSG_ID_GROUP_END_LEN, MAVLINK_MSG_ID_GROUP_END_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE GROUP_END UNPACKING
+
+
+/**
+ * @brief Get field group_id from group_end message
+ *
+ * @return  Mission-unique group id (from MAV_CMD_GROUP_END).
+ */
+static inline uint32_t mavlink_msg_group_end_get_group_id(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  8);
+}
+
+/**
+ * @brief Get field mission_checksum from group_end message
+ *
+ * @return  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.
+ */
+static inline uint32_t mavlink_msg_group_end_get_mission_checksum(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  12);
+}
+
+/**
+ * @brief Get field time_usec from group_end message
+ *
+ * @return [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ */
+static inline uint64_t mavlink_msg_group_end_get_time_usec(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint64_t(msg,  0);
+}
+
+/**
+ * @brief Decode a group_end message into a struct
+ *
+ * @param msg The message to decode
+ * @param group_end C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_group_end_decode(const mavlink_message_t* msg, mavlink_group_end_t* group_end)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    group_end->time_usec = mavlink_msg_group_end_get_time_usec(msg);
+    group_end->group_id = mavlink_msg_group_end_get_group_id(msg);
+    group_end->mission_checksum = mavlink_msg_group_end_get_mission_checksum(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_GROUP_END_LEN? msg->len : MAVLINK_MSG_ID_GROUP_END_LEN;
+        memset(group_end, 0, MAVLINK_MSG_ID_GROUP_END_LEN);
+    memcpy(group_end, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_group_start.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_group_start.h
@@ -1,0 +1,322 @@
+#pragma once
+// MESSAGE GROUP_START PACKING
+
+#define MAVLINK_MSG_ID_GROUP_START 414
+
+
+typedef struct __mavlink_group_start_t {
+ uint64_t time_usec; /*< [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.*/
+ uint32_t group_id; /*<  Mission-unique group id (from MAV_CMD_GROUP_START).*/
+ uint32_t mission_checksum; /*<  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.*/
+} mavlink_group_start_t;
+
+#define MAVLINK_MSG_ID_GROUP_START_LEN 16
+#define MAVLINK_MSG_ID_GROUP_START_MIN_LEN 16
+#define MAVLINK_MSG_ID_414_LEN 16
+#define MAVLINK_MSG_ID_414_MIN_LEN 16
+
+#define MAVLINK_MSG_ID_GROUP_START_CRC 109
+#define MAVLINK_MSG_ID_414_CRC 109
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_GROUP_START { \
+    414, \
+    "GROUP_START", \
+    3, \
+    {  { "group_id", NULL, MAVLINK_TYPE_UINT32_T, 0, 8, offsetof(mavlink_group_start_t, group_id) }, \
+         { "mission_checksum", NULL, MAVLINK_TYPE_UINT32_T, 0, 12, offsetof(mavlink_group_start_t, mission_checksum) }, \
+         { "time_usec", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_group_start_t, time_usec) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_GROUP_START { \
+    "GROUP_START", \
+    3, \
+    {  { "group_id", NULL, MAVLINK_TYPE_UINT32_T, 0, 8, offsetof(mavlink_group_start_t, group_id) }, \
+         { "mission_checksum", NULL, MAVLINK_TYPE_UINT32_T, 0, 12, offsetof(mavlink_group_start_t, mission_checksum) }, \
+         { "time_usec", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_group_start_t, time_usec) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a group_start message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param group_id  Mission-unique group id (from MAV_CMD_GROUP_START).
+ * @param mission_checksum  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_group_start_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint32_t group_id, uint32_t mission_checksum, uint64_t time_usec)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_GROUP_START_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_uint32_t(buf, 8, group_id);
+    _mav_put_uint32_t(buf, 12, mission_checksum);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_GROUP_START_LEN);
+#else
+    mavlink_group_start_t packet;
+    packet.time_usec = time_usec;
+    packet.group_id = group_id;
+    packet.mission_checksum = mission_checksum;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_GROUP_START_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_GROUP_START;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_GROUP_START_MIN_LEN, MAVLINK_MSG_ID_GROUP_START_LEN, MAVLINK_MSG_ID_GROUP_START_CRC);
+}
+
+/**
+ * @brief Pack a group_start message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param group_id  Mission-unique group id (from MAV_CMD_GROUP_START).
+ * @param mission_checksum  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_group_start_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint32_t group_id, uint32_t mission_checksum, uint64_t time_usec)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_GROUP_START_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_uint32_t(buf, 8, group_id);
+    _mav_put_uint32_t(buf, 12, mission_checksum);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_GROUP_START_LEN);
+#else
+    mavlink_group_start_t packet;
+    packet.time_usec = time_usec;
+    packet.group_id = group_id;
+    packet.mission_checksum = mission_checksum;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_GROUP_START_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_GROUP_START;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_GROUP_START_MIN_LEN, MAVLINK_MSG_ID_GROUP_START_LEN, MAVLINK_MSG_ID_GROUP_START_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_GROUP_START_MIN_LEN, MAVLINK_MSG_ID_GROUP_START_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a group_start message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param group_id  Mission-unique group id (from MAV_CMD_GROUP_START).
+ * @param mission_checksum  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_group_start_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint32_t group_id,uint32_t mission_checksum,uint64_t time_usec)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_GROUP_START_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_uint32_t(buf, 8, group_id);
+    _mav_put_uint32_t(buf, 12, mission_checksum);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_GROUP_START_LEN);
+#else
+    mavlink_group_start_t packet;
+    packet.time_usec = time_usec;
+    packet.group_id = group_id;
+    packet.mission_checksum = mission_checksum;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_GROUP_START_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_GROUP_START;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_GROUP_START_MIN_LEN, MAVLINK_MSG_ID_GROUP_START_LEN, MAVLINK_MSG_ID_GROUP_START_CRC);
+}
+
+/**
+ * @brief Encode a group_start struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param group_start C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_group_start_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_group_start_t* group_start)
+{
+    return mavlink_msg_group_start_pack(system_id, component_id, msg, group_start->group_id, group_start->mission_checksum, group_start->time_usec);
+}
+
+/**
+ * @brief Encode a group_start struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param group_start C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_group_start_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_group_start_t* group_start)
+{
+    return mavlink_msg_group_start_pack_chan(system_id, component_id, chan, msg, group_start->group_id, group_start->mission_checksum, group_start->time_usec);
+}
+
+/**
+ * @brief Encode a group_start struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param group_start C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_group_start_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_group_start_t* group_start)
+{
+    return mavlink_msg_group_start_pack_status(system_id, component_id, _status, msg,  group_start->group_id, group_start->mission_checksum, group_start->time_usec);
+}
+
+/**
+ * @brief Send a group_start message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param group_id  Mission-unique group id (from MAV_CMD_GROUP_START).
+ * @param mission_checksum  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.
+ * @param time_usec [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_group_start_send(mavlink_channel_t chan, uint32_t group_id, uint32_t mission_checksum, uint64_t time_usec)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_GROUP_START_LEN];
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_uint32_t(buf, 8, group_id);
+    _mav_put_uint32_t(buf, 12, mission_checksum);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_GROUP_START, buf, MAVLINK_MSG_ID_GROUP_START_MIN_LEN, MAVLINK_MSG_ID_GROUP_START_LEN, MAVLINK_MSG_ID_GROUP_START_CRC);
+#else
+    mavlink_group_start_t packet;
+    packet.time_usec = time_usec;
+    packet.group_id = group_id;
+    packet.mission_checksum = mission_checksum;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_GROUP_START, (const char *)&packet, MAVLINK_MSG_ID_GROUP_START_MIN_LEN, MAVLINK_MSG_ID_GROUP_START_LEN, MAVLINK_MSG_ID_GROUP_START_CRC);
+#endif
+}
+
+/**
+ * @brief Send a group_start message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_group_start_send_struct(mavlink_channel_t chan, const mavlink_group_start_t* group_start)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_group_start_send(chan, group_start->group_id, group_start->mission_checksum, group_start->time_usec);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_GROUP_START, (const char *)group_start, MAVLINK_MSG_ID_GROUP_START_MIN_LEN, MAVLINK_MSG_ID_GROUP_START_LEN, MAVLINK_MSG_ID_GROUP_START_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_GROUP_START_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_group_start_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint32_t group_id, uint32_t mission_checksum, uint64_t time_usec)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint64_t(buf, 0, time_usec);
+    _mav_put_uint32_t(buf, 8, group_id);
+    _mav_put_uint32_t(buf, 12, mission_checksum);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_GROUP_START, buf, MAVLINK_MSG_ID_GROUP_START_MIN_LEN, MAVLINK_MSG_ID_GROUP_START_LEN, MAVLINK_MSG_ID_GROUP_START_CRC);
+#else
+    mavlink_group_start_t *packet = (mavlink_group_start_t *)msgbuf;
+    packet->time_usec = time_usec;
+    packet->group_id = group_id;
+    packet->mission_checksum = mission_checksum;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_GROUP_START, (const char *)packet, MAVLINK_MSG_ID_GROUP_START_MIN_LEN, MAVLINK_MSG_ID_GROUP_START_LEN, MAVLINK_MSG_ID_GROUP_START_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE GROUP_START UNPACKING
+
+
+/**
+ * @brief Get field group_id from group_start message
+ *
+ * @return  Mission-unique group id (from MAV_CMD_GROUP_START).
+ */
+static inline uint32_t mavlink_msg_group_start_get_group_id(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  8);
+}
+
+/**
+ * @brief Get field mission_checksum from group_start message
+ *
+ * @return  CRC32 checksum of current plan for MAV_MISSION_TYPE_ALL. As defined in MISSION_CHECKSUM message.
+ */
+static inline uint32_t mavlink_msg_group_start_get_mission_checksum(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  12);
+}
+
+/**
+ * @brief Get field time_usec from group_start message
+ *
+ * @return [us] Timestamp (UNIX Epoch time or time since system boot).
+        The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.
+ */
+static inline uint64_t mavlink_msg_group_start_get_time_usec(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint64_t(msg,  0);
+}
+
+/**
+ * @brief Decode a group_start message into a struct
+ *
+ * @param msg The message to decode
+ * @param group_start C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_group_start_decode(const mavlink_message_t* msg, mavlink_group_start_t* group_start)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    group_start->time_usec = mavlink_msg_group_start_get_time_usec(msg);
+    group_start->group_id = mavlink_msg_group_start_get_group_id(msg);
+    group_start->mission_checksum = mavlink_msg_group_start_get_mission_checksum(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_GROUP_START_LEN? msg->len : MAVLINK_MSG_ID_GROUP_START_LEN;
+        memset(group_start, 0, MAVLINK_MSG_ID_GROUP_START_LEN);
+    memcpy(group_start, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_mission_checksum.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_mission_checksum.h
@@ -1,0 +1,288 @@
+#pragma once
+// MESSAGE MISSION_CHECKSUM PACKING
+
+#define MAVLINK_MSG_ID_MISSION_CHECKSUM 53
+
+
+typedef struct __mavlink_mission_checksum_t {
+ uint32_t checksum; /*<  CRC32 checksum of current plan for specified type.*/
+ uint8_t mission_type; /*<  Mission type.*/
+} mavlink_mission_checksum_t;
+
+#define MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN 5
+#define MAVLINK_MSG_ID_MISSION_CHECKSUM_MIN_LEN 5
+#define MAVLINK_MSG_ID_53_LEN 5
+#define MAVLINK_MSG_ID_53_MIN_LEN 5
+
+#define MAVLINK_MSG_ID_MISSION_CHECKSUM_CRC 3
+#define MAVLINK_MSG_ID_53_CRC 3
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_MISSION_CHECKSUM { \
+    53, \
+    "MISSION_CHECKSUM", \
+    2, \
+    {  { "mission_type", NULL, MAVLINK_TYPE_UINT8_T, 0, 4, offsetof(mavlink_mission_checksum_t, mission_type) }, \
+         { "checksum", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_mission_checksum_t, checksum) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_MISSION_CHECKSUM { \
+    "MISSION_CHECKSUM", \
+    2, \
+    {  { "mission_type", NULL, MAVLINK_TYPE_UINT8_T, 0, 4, offsetof(mavlink_mission_checksum_t, mission_type) }, \
+         { "checksum", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_mission_checksum_t, checksum) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a mission_checksum message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param mission_type  Mission type.
+ * @param checksum  CRC32 checksum of current plan for specified type.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_mission_checksum_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint8_t mission_type, uint32_t checksum)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN];
+    _mav_put_uint32_t(buf, 0, checksum);
+    _mav_put_uint8_t(buf, 4, mission_type);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN);
+#else
+    mavlink_mission_checksum_t packet;
+    packet.checksum = checksum;
+    packet.mission_type = mission_type;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_MISSION_CHECKSUM;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_MISSION_CHECKSUM_MIN_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_CRC);
+}
+
+/**
+ * @brief Pack a mission_checksum message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param mission_type  Mission type.
+ * @param checksum  CRC32 checksum of current plan for specified type.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_mission_checksum_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint8_t mission_type, uint32_t checksum)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN];
+    _mav_put_uint32_t(buf, 0, checksum);
+    _mav_put_uint8_t(buf, 4, mission_type);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN);
+#else
+    mavlink_mission_checksum_t packet;
+    packet.checksum = checksum;
+    packet.mission_type = mission_type;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_MISSION_CHECKSUM;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_MISSION_CHECKSUM_MIN_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_MISSION_CHECKSUM_MIN_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a mission_checksum message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param mission_type  Mission type.
+ * @param checksum  CRC32 checksum of current plan for specified type.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_mission_checksum_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint8_t mission_type,uint32_t checksum)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN];
+    _mav_put_uint32_t(buf, 0, checksum);
+    _mav_put_uint8_t(buf, 4, mission_type);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN);
+#else
+    mavlink_mission_checksum_t packet;
+    packet.checksum = checksum;
+    packet.mission_type = mission_type;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_MISSION_CHECKSUM;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_MISSION_CHECKSUM_MIN_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_CRC);
+}
+
+/**
+ * @brief Encode a mission_checksum struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param mission_checksum C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_mission_checksum_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_mission_checksum_t* mission_checksum)
+{
+    return mavlink_msg_mission_checksum_pack(system_id, component_id, msg, mission_checksum->mission_type, mission_checksum->checksum);
+}
+
+/**
+ * @brief Encode a mission_checksum struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param mission_checksum C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_mission_checksum_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_mission_checksum_t* mission_checksum)
+{
+    return mavlink_msg_mission_checksum_pack_chan(system_id, component_id, chan, msg, mission_checksum->mission_type, mission_checksum->checksum);
+}
+
+/**
+ * @brief Encode a mission_checksum struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param mission_checksum C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_mission_checksum_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_mission_checksum_t* mission_checksum)
+{
+    return mavlink_msg_mission_checksum_pack_status(system_id, component_id, _status, msg,  mission_checksum->mission_type, mission_checksum->checksum);
+}
+
+/**
+ * @brief Send a mission_checksum message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param mission_type  Mission type.
+ * @param checksum  CRC32 checksum of current plan for specified type.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_mission_checksum_send(mavlink_channel_t chan, uint8_t mission_type, uint32_t checksum)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN];
+    _mav_put_uint32_t(buf, 0, checksum);
+    _mav_put_uint8_t(buf, 4, mission_type);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_MISSION_CHECKSUM, buf, MAVLINK_MSG_ID_MISSION_CHECKSUM_MIN_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_CRC);
+#else
+    mavlink_mission_checksum_t packet;
+    packet.checksum = checksum;
+    packet.mission_type = mission_type;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_MISSION_CHECKSUM, (const char *)&packet, MAVLINK_MSG_ID_MISSION_CHECKSUM_MIN_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_CRC);
+#endif
+}
+
+/**
+ * @brief Send a mission_checksum message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_mission_checksum_send_struct(mavlink_channel_t chan, const mavlink_mission_checksum_t* mission_checksum)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_mission_checksum_send(chan, mission_checksum->mission_type, mission_checksum->checksum);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_MISSION_CHECKSUM, (const char *)mission_checksum, MAVLINK_MSG_ID_MISSION_CHECKSUM_MIN_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_mission_checksum_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint8_t mission_type, uint32_t checksum)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint32_t(buf, 0, checksum);
+    _mav_put_uint8_t(buf, 4, mission_type);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_MISSION_CHECKSUM, buf, MAVLINK_MSG_ID_MISSION_CHECKSUM_MIN_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_CRC);
+#else
+    mavlink_mission_checksum_t *packet = (mavlink_mission_checksum_t *)msgbuf;
+    packet->checksum = checksum;
+    packet->mission_type = mission_type;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_MISSION_CHECKSUM, (const char *)packet, MAVLINK_MSG_ID_MISSION_CHECKSUM_MIN_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN, MAVLINK_MSG_ID_MISSION_CHECKSUM_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE MISSION_CHECKSUM UNPACKING
+
+
+/**
+ * @brief Get field mission_type from mission_checksum message
+ *
+ * @return  Mission type.
+ */
+static inline uint8_t mavlink_msg_mission_checksum_get_mission_type(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  4);
+}
+
+/**
+ * @brief Get field checksum from mission_checksum message
+ *
+ * @return  CRC32 checksum of current plan for specified type.
+ */
+static inline uint32_t mavlink_msg_mission_checksum_get_checksum(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  0);
+}
+
+/**
+ * @brief Decode a mission_checksum message into a struct
+ *
+ * @param msg The message to decode
+ * @param mission_checksum C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_mission_checksum_decode(const mavlink_message_t* msg, mavlink_mission_checksum_t* mission_checksum)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mission_checksum->checksum = mavlink_msg_mission_checksum_get_checksum(msg);
+    mission_checksum->mission_type = mavlink_msg_mission_checksum_get_mission_type(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN? msg->len : MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN;
+        memset(mission_checksum, 0, MAVLINK_MSG_ID_MISSION_CHECKSUM_LEN);
+    memcpy(mission_checksum, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_param_ack_transaction.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_param_ack_transaction.h
@@ -1,0 +1,390 @@
+#pragma once
+// MESSAGE PARAM_ACK_TRANSACTION PACKING
+
+#define MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION 19
+
+
+typedef struct __mavlink_param_ack_transaction_t {
+ float param_value; /*<  Parameter value (new value if PARAM_ACCEPTED, current value otherwise)*/
+ uint8_t target_system; /*<  Id of system that sent PARAM_SET message.*/
+ uint8_t target_component; /*<  Id of system that sent PARAM_SET message.*/
+ char param_id[16]; /*<  Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string*/
+ uint8_t param_type; /*<  Parameter type.*/
+ uint8_t param_result; /*<  Result code.*/
+} mavlink_param_ack_transaction_t;
+
+#define MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN 24
+#define MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_MIN_LEN 24
+#define MAVLINK_MSG_ID_19_LEN 24
+#define MAVLINK_MSG_ID_19_MIN_LEN 24
+
+#define MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_CRC 137
+#define MAVLINK_MSG_ID_19_CRC 137
+
+#define MAVLINK_MSG_PARAM_ACK_TRANSACTION_FIELD_PARAM_ID_LEN 16
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_PARAM_ACK_TRANSACTION { \
+    19, \
+    "PARAM_ACK_TRANSACTION", \
+    6, \
+    {  { "target_system", NULL, MAVLINK_TYPE_UINT8_T, 0, 4, offsetof(mavlink_param_ack_transaction_t, target_system) }, \
+         { "target_component", NULL, MAVLINK_TYPE_UINT8_T, 0, 5, offsetof(mavlink_param_ack_transaction_t, target_component) }, \
+         { "param_id", NULL, MAVLINK_TYPE_CHAR, 16, 6, offsetof(mavlink_param_ack_transaction_t, param_id) }, \
+         { "param_value", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_param_ack_transaction_t, param_value) }, \
+         { "param_type", NULL, MAVLINK_TYPE_UINT8_T, 0, 22, offsetof(mavlink_param_ack_transaction_t, param_type) }, \
+         { "param_result", NULL, MAVLINK_TYPE_UINT8_T, 0, 23, offsetof(mavlink_param_ack_transaction_t, param_result) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_PARAM_ACK_TRANSACTION { \
+    "PARAM_ACK_TRANSACTION", \
+    6, \
+    {  { "target_system", NULL, MAVLINK_TYPE_UINT8_T, 0, 4, offsetof(mavlink_param_ack_transaction_t, target_system) }, \
+         { "target_component", NULL, MAVLINK_TYPE_UINT8_T, 0, 5, offsetof(mavlink_param_ack_transaction_t, target_component) }, \
+         { "param_id", NULL, MAVLINK_TYPE_CHAR, 16, 6, offsetof(mavlink_param_ack_transaction_t, param_id) }, \
+         { "param_value", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_param_ack_transaction_t, param_value) }, \
+         { "param_type", NULL, MAVLINK_TYPE_UINT8_T, 0, 22, offsetof(mavlink_param_ack_transaction_t, param_type) }, \
+         { "param_result", NULL, MAVLINK_TYPE_UINT8_T, 0, 23, offsetof(mavlink_param_ack_transaction_t, param_result) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a param_ack_transaction message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param target_system  Id of system that sent PARAM_SET message.
+ * @param target_component  Id of system that sent PARAM_SET message.
+ * @param param_id  Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string
+ * @param param_value  Parameter value (new value if PARAM_ACCEPTED, current value otherwise)
+ * @param param_type  Parameter type.
+ * @param param_result  Result code.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_param_ack_transaction_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint8_t target_system, uint8_t target_component, const char *param_id, float param_value, uint8_t param_type, uint8_t param_result)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN];
+    _mav_put_float(buf, 0, param_value);
+    _mav_put_uint8_t(buf, 4, target_system);
+    _mav_put_uint8_t(buf, 5, target_component);
+    _mav_put_uint8_t(buf, 22, param_type);
+    _mav_put_uint8_t(buf, 23, param_result);
+    _mav_put_char_array(buf, 6, param_id, 16);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN);
+#else
+    mavlink_param_ack_transaction_t packet;
+    packet.param_value = param_value;
+    packet.target_system = target_system;
+    packet.target_component = target_component;
+    packet.param_type = param_type;
+    packet.param_result = param_result;
+    mav_array_memcpy(packet.param_id, param_id, sizeof(char)*16);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_MIN_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_CRC);
+}
+
+/**
+ * @brief Pack a param_ack_transaction message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param target_system  Id of system that sent PARAM_SET message.
+ * @param target_component  Id of system that sent PARAM_SET message.
+ * @param param_id  Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string
+ * @param param_value  Parameter value (new value if PARAM_ACCEPTED, current value otherwise)
+ * @param param_type  Parameter type.
+ * @param param_result  Result code.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_param_ack_transaction_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint8_t target_system, uint8_t target_component, const char *param_id, float param_value, uint8_t param_type, uint8_t param_result)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN];
+    _mav_put_float(buf, 0, param_value);
+    _mav_put_uint8_t(buf, 4, target_system);
+    _mav_put_uint8_t(buf, 5, target_component);
+    _mav_put_uint8_t(buf, 22, param_type);
+    _mav_put_uint8_t(buf, 23, param_result);
+    _mav_put_char_array(buf, 6, param_id, 16);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN);
+#else
+    mavlink_param_ack_transaction_t packet;
+    packet.param_value = param_value;
+    packet.target_system = target_system;
+    packet.target_component = target_component;
+    packet.param_type = param_type;
+    packet.param_result = param_result;
+    mav_array_memcpy(packet.param_id, param_id, sizeof(char)*16);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_MIN_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_MIN_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a param_ack_transaction message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param target_system  Id of system that sent PARAM_SET message.
+ * @param target_component  Id of system that sent PARAM_SET message.
+ * @param param_id  Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string
+ * @param param_value  Parameter value (new value if PARAM_ACCEPTED, current value otherwise)
+ * @param param_type  Parameter type.
+ * @param param_result  Result code.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_param_ack_transaction_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint8_t target_system,uint8_t target_component,const char *param_id,float param_value,uint8_t param_type,uint8_t param_result)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN];
+    _mav_put_float(buf, 0, param_value);
+    _mav_put_uint8_t(buf, 4, target_system);
+    _mav_put_uint8_t(buf, 5, target_component);
+    _mav_put_uint8_t(buf, 22, param_type);
+    _mav_put_uint8_t(buf, 23, param_result);
+    _mav_put_char_array(buf, 6, param_id, 16);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN);
+#else
+    mavlink_param_ack_transaction_t packet;
+    packet.param_value = param_value;
+    packet.target_system = target_system;
+    packet.target_component = target_component;
+    packet.param_type = param_type;
+    packet.param_result = param_result;
+    mav_array_memcpy(packet.param_id, param_id, sizeof(char)*16);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_MIN_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_CRC);
+}
+
+/**
+ * @brief Encode a param_ack_transaction struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param param_ack_transaction C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_param_ack_transaction_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_param_ack_transaction_t* param_ack_transaction)
+{
+    return mavlink_msg_param_ack_transaction_pack(system_id, component_id, msg, param_ack_transaction->target_system, param_ack_transaction->target_component, param_ack_transaction->param_id, param_ack_transaction->param_value, param_ack_transaction->param_type, param_ack_transaction->param_result);
+}
+
+/**
+ * @brief Encode a param_ack_transaction struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param param_ack_transaction C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_param_ack_transaction_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_param_ack_transaction_t* param_ack_transaction)
+{
+    return mavlink_msg_param_ack_transaction_pack_chan(system_id, component_id, chan, msg, param_ack_transaction->target_system, param_ack_transaction->target_component, param_ack_transaction->param_id, param_ack_transaction->param_value, param_ack_transaction->param_type, param_ack_transaction->param_result);
+}
+
+/**
+ * @brief Encode a param_ack_transaction struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param param_ack_transaction C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_param_ack_transaction_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_param_ack_transaction_t* param_ack_transaction)
+{
+    return mavlink_msg_param_ack_transaction_pack_status(system_id, component_id, _status, msg,  param_ack_transaction->target_system, param_ack_transaction->target_component, param_ack_transaction->param_id, param_ack_transaction->param_value, param_ack_transaction->param_type, param_ack_transaction->param_result);
+}
+
+/**
+ * @brief Send a param_ack_transaction message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param target_system  Id of system that sent PARAM_SET message.
+ * @param target_component  Id of system that sent PARAM_SET message.
+ * @param param_id  Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string
+ * @param param_value  Parameter value (new value if PARAM_ACCEPTED, current value otherwise)
+ * @param param_type  Parameter type.
+ * @param param_result  Result code.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_param_ack_transaction_send(mavlink_channel_t chan, uint8_t target_system, uint8_t target_component, const char *param_id, float param_value, uint8_t param_type, uint8_t param_result)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN];
+    _mav_put_float(buf, 0, param_value);
+    _mav_put_uint8_t(buf, 4, target_system);
+    _mav_put_uint8_t(buf, 5, target_component);
+    _mav_put_uint8_t(buf, 22, param_type);
+    _mav_put_uint8_t(buf, 23, param_result);
+    _mav_put_char_array(buf, 6, param_id, 16);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION, buf, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_MIN_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_CRC);
+#else
+    mavlink_param_ack_transaction_t packet;
+    packet.param_value = param_value;
+    packet.target_system = target_system;
+    packet.target_component = target_component;
+    packet.param_type = param_type;
+    packet.param_result = param_result;
+    mav_array_memcpy(packet.param_id, param_id, sizeof(char)*16);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION, (const char *)&packet, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_MIN_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_CRC);
+#endif
+}
+
+/**
+ * @brief Send a param_ack_transaction message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_param_ack_transaction_send_struct(mavlink_channel_t chan, const mavlink_param_ack_transaction_t* param_ack_transaction)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_param_ack_transaction_send(chan, param_ack_transaction->target_system, param_ack_transaction->target_component, param_ack_transaction->param_id, param_ack_transaction->param_value, param_ack_transaction->param_type, param_ack_transaction->param_result);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION, (const char *)param_ack_transaction, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_MIN_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_param_ack_transaction_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint8_t target_system, uint8_t target_component, const char *param_id, float param_value, uint8_t param_type, uint8_t param_result)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_float(buf, 0, param_value);
+    _mav_put_uint8_t(buf, 4, target_system);
+    _mav_put_uint8_t(buf, 5, target_component);
+    _mav_put_uint8_t(buf, 22, param_type);
+    _mav_put_uint8_t(buf, 23, param_result);
+    _mav_put_char_array(buf, 6, param_id, 16);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION, buf, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_MIN_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_CRC);
+#else
+    mavlink_param_ack_transaction_t *packet = (mavlink_param_ack_transaction_t *)msgbuf;
+    packet->param_value = param_value;
+    packet->target_system = target_system;
+    packet->target_component = target_component;
+    packet->param_type = param_type;
+    packet->param_result = param_result;
+    mav_array_memcpy(packet->param_id, param_id, sizeof(char)*16);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION, (const char *)packet, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_MIN_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE PARAM_ACK_TRANSACTION UNPACKING
+
+
+/**
+ * @brief Get field target_system from param_ack_transaction message
+ *
+ * @return  Id of system that sent PARAM_SET message.
+ */
+static inline uint8_t mavlink_msg_param_ack_transaction_get_target_system(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  4);
+}
+
+/**
+ * @brief Get field target_component from param_ack_transaction message
+ *
+ * @return  Id of system that sent PARAM_SET message.
+ */
+static inline uint8_t mavlink_msg_param_ack_transaction_get_target_component(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  5);
+}
+
+/**
+ * @brief Get field param_id from param_ack_transaction message
+ *
+ * @return  Parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string
+ */
+static inline uint16_t mavlink_msg_param_ack_transaction_get_param_id(const mavlink_message_t* msg, char *param_id)
+{
+    return _MAV_RETURN_char_array(msg, param_id, 16,  6);
+}
+
+/**
+ * @brief Get field param_value from param_ack_transaction message
+ *
+ * @return  Parameter value (new value if PARAM_ACCEPTED, current value otherwise)
+ */
+static inline float mavlink_msg_param_ack_transaction_get_param_value(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  0);
+}
+
+/**
+ * @brief Get field param_type from param_ack_transaction message
+ *
+ * @return  Parameter type.
+ */
+static inline uint8_t mavlink_msg_param_ack_transaction_get_param_type(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  22);
+}
+
+/**
+ * @brief Get field param_result from param_ack_transaction message
+ *
+ * @return  Result code.
+ */
+static inline uint8_t mavlink_msg_param_ack_transaction_get_param_result(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  23);
+}
+
+/**
+ * @brief Decode a param_ack_transaction message into a struct
+ *
+ * @param msg The message to decode
+ * @param param_ack_transaction C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_param_ack_transaction_decode(const mavlink_message_t* msg, mavlink_param_ack_transaction_t* param_ack_transaction)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    param_ack_transaction->param_value = mavlink_msg_param_ack_transaction_get_param_value(msg);
+    param_ack_transaction->target_system = mavlink_msg_param_ack_transaction_get_target_system(msg);
+    param_ack_transaction->target_component = mavlink_msg_param_ack_transaction_get_target_component(msg);
+    mavlink_msg_param_ack_transaction_get_param_id(msg, param_ack_transaction->param_id);
+    param_ack_transaction->param_type = mavlink_msg_param_ack_transaction_get_param_type(msg);
+    param_ack_transaction->param_result = mavlink_msg_param_ack_transaction_get_param_result(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN? msg->len : MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN;
+        memset(param_ack_transaction, 0, MAVLINK_MSG_ID_PARAM_ACK_TRANSACTION_LEN);
+    memcpy(param_ack_transaction, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_target_absolute.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_target_absolute.h
@@ -1,0 +1,592 @@
+#pragma once
+// MESSAGE TARGET_ABSOLUTE PACKING
+
+#define MAVLINK_MSG_ID_TARGET_ABSOLUTE 510
+
+
+typedef struct __mavlink_target_absolute_t {
+ uint64_t timestamp; /*< [us] Timestamp (UNIX epoch time).*/
+ int32_t lat; /*< [degE7] Target's latitude (WGS84)*/
+ int32_t lon; /*< [degE7] Target's longitude (WGS84)*/
+ float alt; /*< [m] Target's altitude (AMSL)*/
+ float vel[3]; /*< [m/s] Target's velocity in its body frame*/
+ float acc[3]; /*< [m/s/s] Linear target's acceleration in its body frame*/
+ float q_target[4]; /*<  Quaternion of the target's orientation from its body frame to the vehicle's NED frame.*/
+ float rates[3]; /*< [rad/s] Target's roll, pitch and yaw rates*/
+ float position_std[2]; /*< [m] Standard deviation of horizontal (eph) and vertical (epv) position errors*/
+ float vel_std[3]; /*< [m/s] Standard deviation of the target's velocity in its body frame*/
+ float acc_std[3]; /*< [m/s/s] Standard deviation of the target's acceleration in its body frame*/
+ uint8_t id; /*<  The ID of the target if multiple targets are present*/
+ uint8_t sensor_capabilities; /*<  Bitmap to indicate the sensor's reporting capabilities*/
+} mavlink_target_absolute_t;
+
+#define MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN 106
+#define MAVLINK_MSG_ID_TARGET_ABSOLUTE_MIN_LEN 106
+#define MAVLINK_MSG_ID_510_LEN 106
+#define MAVLINK_MSG_ID_510_MIN_LEN 106
+
+#define MAVLINK_MSG_ID_TARGET_ABSOLUTE_CRC 245
+#define MAVLINK_MSG_ID_510_CRC 245
+
+#define MAVLINK_MSG_TARGET_ABSOLUTE_FIELD_VEL_LEN 3
+#define MAVLINK_MSG_TARGET_ABSOLUTE_FIELD_ACC_LEN 3
+#define MAVLINK_MSG_TARGET_ABSOLUTE_FIELD_Q_TARGET_LEN 4
+#define MAVLINK_MSG_TARGET_ABSOLUTE_FIELD_RATES_LEN 3
+#define MAVLINK_MSG_TARGET_ABSOLUTE_FIELD_POSITION_STD_LEN 2
+#define MAVLINK_MSG_TARGET_ABSOLUTE_FIELD_VEL_STD_LEN 3
+#define MAVLINK_MSG_TARGET_ABSOLUTE_FIELD_ACC_STD_LEN 3
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_TARGET_ABSOLUTE { \
+    510, \
+    "TARGET_ABSOLUTE", \
+    13, \
+    {  { "timestamp", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_target_absolute_t, timestamp) }, \
+         { "id", NULL, MAVLINK_TYPE_UINT8_T, 0, 104, offsetof(mavlink_target_absolute_t, id) }, \
+         { "sensor_capabilities", NULL, MAVLINK_TYPE_UINT8_T, 0, 105, offsetof(mavlink_target_absolute_t, sensor_capabilities) }, \
+         { "lat", NULL, MAVLINK_TYPE_INT32_T, 0, 8, offsetof(mavlink_target_absolute_t, lat) }, \
+         { "lon", NULL, MAVLINK_TYPE_INT32_T, 0, 12, offsetof(mavlink_target_absolute_t, lon) }, \
+         { "alt", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_target_absolute_t, alt) }, \
+         { "vel", NULL, MAVLINK_TYPE_FLOAT, 3, 20, offsetof(mavlink_target_absolute_t, vel) }, \
+         { "acc", NULL, MAVLINK_TYPE_FLOAT, 3, 32, offsetof(mavlink_target_absolute_t, acc) }, \
+         { "q_target", NULL, MAVLINK_TYPE_FLOAT, 4, 44, offsetof(mavlink_target_absolute_t, q_target) }, \
+         { "rates", NULL, MAVLINK_TYPE_FLOAT, 3, 60, offsetof(mavlink_target_absolute_t, rates) }, \
+         { "position_std", NULL, MAVLINK_TYPE_FLOAT, 2, 72, offsetof(mavlink_target_absolute_t, position_std) }, \
+         { "vel_std", NULL, MAVLINK_TYPE_FLOAT, 3, 80, offsetof(mavlink_target_absolute_t, vel_std) }, \
+         { "acc_std", NULL, MAVLINK_TYPE_FLOAT, 3, 92, offsetof(mavlink_target_absolute_t, acc_std) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_TARGET_ABSOLUTE { \
+    "TARGET_ABSOLUTE", \
+    13, \
+    {  { "timestamp", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_target_absolute_t, timestamp) }, \
+         { "id", NULL, MAVLINK_TYPE_UINT8_T, 0, 104, offsetof(mavlink_target_absolute_t, id) }, \
+         { "sensor_capabilities", NULL, MAVLINK_TYPE_UINT8_T, 0, 105, offsetof(mavlink_target_absolute_t, sensor_capabilities) }, \
+         { "lat", NULL, MAVLINK_TYPE_INT32_T, 0, 8, offsetof(mavlink_target_absolute_t, lat) }, \
+         { "lon", NULL, MAVLINK_TYPE_INT32_T, 0, 12, offsetof(mavlink_target_absolute_t, lon) }, \
+         { "alt", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_target_absolute_t, alt) }, \
+         { "vel", NULL, MAVLINK_TYPE_FLOAT, 3, 20, offsetof(mavlink_target_absolute_t, vel) }, \
+         { "acc", NULL, MAVLINK_TYPE_FLOAT, 3, 32, offsetof(mavlink_target_absolute_t, acc) }, \
+         { "q_target", NULL, MAVLINK_TYPE_FLOAT, 4, 44, offsetof(mavlink_target_absolute_t, q_target) }, \
+         { "rates", NULL, MAVLINK_TYPE_FLOAT, 3, 60, offsetof(mavlink_target_absolute_t, rates) }, \
+         { "position_std", NULL, MAVLINK_TYPE_FLOAT, 2, 72, offsetof(mavlink_target_absolute_t, position_std) }, \
+         { "vel_std", NULL, MAVLINK_TYPE_FLOAT, 3, 80, offsetof(mavlink_target_absolute_t, vel_std) }, \
+         { "acc_std", NULL, MAVLINK_TYPE_FLOAT, 3, 92, offsetof(mavlink_target_absolute_t, acc_std) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a target_absolute message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param timestamp [us] Timestamp (UNIX epoch time).
+ * @param id  The ID of the target if multiple targets are present
+ * @param sensor_capabilities  Bitmap to indicate the sensor's reporting capabilities
+ * @param lat [degE7] Target's latitude (WGS84)
+ * @param lon [degE7] Target's longitude (WGS84)
+ * @param alt [m] Target's altitude (AMSL)
+ * @param vel [m/s] Target's velocity in its body frame
+ * @param acc [m/s/s] Linear target's acceleration in its body frame
+ * @param q_target  Quaternion of the target's orientation from its body frame to the vehicle's NED frame.
+ * @param rates [rad/s] Target's roll, pitch and yaw rates
+ * @param position_std [m] Standard deviation of horizontal (eph) and vertical (epv) position errors
+ * @param vel_std [m/s] Standard deviation of the target's velocity in its body frame
+ * @param acc_std [m/s/s] Standard deviation of the target's acceleration in its body frame
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_target_absolute_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint64_t timestamp, uint8_t id, uint8_t sensor_capabilities, int32_t lat, int32_t lon, float alt, const float *vel, const float *acc, const float *q_target, const float *rates, const float *position_std, const float *vel_std, const float *acc_std)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN];
+    _mav_put_uint64_t(buf, 0, timestamp);
+    _mav_put_int32_t(buf, 8, lat);
+    _mav_put_int32_t(buf, 12, lon);
+    _mav_put_float(buf, 16, alt);
+    _mav_put_uint8_t(buf, 104, id);
+    _mav_put_uint8_t(buf, 105, sensor_capabilities);
+    _mav_put_float_array(buf, 20, vel, 3);
+    _mav_put_float_array(buf, 32, acc, 3);
+    _mav_put_float_array(buf, 44, q_target, 4);
+    _mav_put_float_array(buf, 60, rates, 3);
+    _mav_put_float_array(buf, 72, position_std, 2);
+    _mav_put_float_array(buf, 80, vel_std, 3);
+    _mav_put_float_array(buf, 92, acc_std, 3);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN);
+#else
+    mavlink_target_absolute_t packet;
+    packet.timestamp = timestamp;
+    packet.lat = lat;
+    packet.lon = lon;
+    packet.alt = alt;
+    packet.id = id;
+    packet.sensor_capabilities = sensor_capabilities;
+    mav_array_memcpy(packet.vel, vel, sizeof(float)*3);
+    mav_array_memcpy(packet.acc, acc, sizeof(float)*3);
+    mav_array_memcpy(packet.q_target, q_target, sizeof(float)*4);
+    mav_array_memcpy(packet.rates, rates, sizeof(float)*3);
+    mav_array_memcpy(packet.position_std, position_std, sizeof(float)*2);
+    mav_array_memcpy(packet.vel_std, vel_std, sizeof(float)*3);
+    mav_array_memcpy(packet.acc_std, acc_std, sizeof(float)*3);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_TARGET_ABSOLUTE;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_TARGET_ABSOLUTE_MIN_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_CRC);
+}
+
+/**
+ * @brief Pack a target_absolute message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param timestamp [us] Timestamp (UNIX epoch time).
+ * @param id  The ID of the target if multiple targets are present
+ * @param sensor_capabilities  Bitmap to indicate the sensor's reporting capabilities
+ * @param lat [degE7] Target's latitude (WGS84)
+ * @param lon [degE7] Target's longitude (WGS84)
+ * @param alt [m] Target's altitude (AMSL)
+ * @param vel [m/s] Target's velocity in its body frame
+ * @param acc [m/s/s] Linear target's acceleration in its body frame
+ * @param q_target  Quaternion of the target's orientation from its body frame to the vehicle's NED frame.
+ * @param rates [rad/s] Target's roll, pitch and yaw rates
+ * @param position_std [m] Standard deviation of horizontal (eph) and vertical (epv) position errors
+ * @param vel_std [m/s] Standard deviation of the target's velocity in its body frame
+ * @param acc_std [m/s/s] Standard deviation of the target's acceleration in its body frame
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_target_absolute_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint64_t timestamp, uint8_t id, uint8_t sensor_capabilities, int32_t lat, int32_t lon, float alt, const float *vel, const float *acc, const float *q_target, const float *rates, const float *position_std, const float *vel_std, const float *acc_std)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN];
+    _mav_put_uint64_t(buf, 0, timestamp);
+    _mav_put_int32_t(buf, 8, lat);
+    _mav_put_int32_t(buf, 12, lon);
+    _mav_put_float(buf, 16, alt);
+    _mav_put_uint8_t(buf, 104, id);
+    _mav_put_uint8_t(buf, 105, sensor_capabilities);
+    _mav_put_float_array(buf, 20, vel, 3);
+    _mav_put_float_array(buf, 32, acc, 3);
+    _mav_put_float_array(buf, 44, q_target, 4);
+    _mav_put_float_array(buf, 60, rates, 3);
+    _mav_put_float_array(buf, 72, position_std, 2);
+    _mav_put_float_array(buf, 80, vel_std, 3);
+    _mav_put_float_array(buf, 92, acc_std, 3);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN);
+#else
+    mavlink_target_absolute_t packet;
+    packet.timestamp = timestamp;
+    packet.lat = lat;
+    packet.lon = lon;
+    packet.alt = alt;
+    packet.id = id;
+    packet.sensor_capabilities = sensor_capabilities;
+    mav_array_memcpy(packet.vel, vel, sizeof(float)*3);
+    mav_array_memcpy(packet.acc, acc, sizeof(float)*3);
+    mav_array_memcpy(packet.q_target, q_target, sizeof(float)*4);
+    mav_array_memcpy(packet.rates, rates, sizeof(float)*3);
+    mav_array_memcpy(packet.position_std, position_std, sizeof(float)*2);
+    mav_array_memcpy(packet.vel_std, vel_std, sizeof(float)*3);
+    mav_array_memcpy(packet.acc_std, acc_std, sizeof(float)*3);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_TARGET_ABSOLUTE;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_TARGET_ABSOLUTE_MIN_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_TARGET_ABSOLUTE_MIN_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a target_absolute message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param timestamp [us] Timestamp (UNIX epoch time).
+ * @param id  The ID of the target if multiple targets are present
+ * @param sensor_capabilities  Bitmap to indicate the sensor's reporting capabilities
+ * @param lat [degE7] Target's latitude (WGS84)
+ * @param lon [degE7] Target's longitude (WGS84)
+ * @param alt [m] Target's altitude (AMSL)
+ * @param vel [m/s] Target's velocity in its body frame
+ * @param acc [m/s/s] Linear target's acceleration in its body frame
+ * @param q_target  Quaternion of the target's orientation from its body frame to the vehicle's NED frame.
+ * @param rates [rad/s] Target's roll, pitch and yaw rates
+ * @param position_std [m] Standard deviation of horizontal (eph) and vertical (epv) position errors
+ * @param vel_std [m/s] Standard deviation of the target's velocity in its body frame
+ * @param acc_std [m/s/s] Standard deviation of the target's acceleration in its body frame
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_target_absolute_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint64_t timestamp,uint8_t id,uint8_t sensor_capabilities,int32_t lat,int32_t lon,float alt,const float *vel,const float *acc,const float *q_target,const float *rates,const float *position_std,const float *vel_std,const float *acc_std)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN];
+    _mav_put_uint64_t(buf, 0, timestamp);
+    _mav_put_int32_t(buf, 8, lat);
+    _mav_put_int32_t(buf, 12, lon);
+    _mav_put_float(buf, 16, alt);
+    _mav_put_uint8_t(buf, 104, id);
+    _mav_put_uint8_t(buf, 105, sensor_capabilities);
+    _mav_put_float_array(buf, 20, vel, 3);
+    _mav_put_float_array(buf, 32, acc, 3);
+    _mav_put_float_array(buf, 44, q_target, 4);
+    _mav_put_float_array(buf, 60, rates, 3);
+    _mav_put_float_array(buf, 72, position_std, 2);
+    _mav_put_float_array(buf, 80, vel_std, 3);
+    _mav_put_float_array(buf, 92, acc_std, 3);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN);
+#else
+    mavlink_target_absolute_t packet;
+    packet.timestamp = timestamp;
+    packet.lat = lat;
+    packet.lon = lon;
+    packet.alt = alt;
+    packet.id = id;
+    packet.sensor_capabilities = sensor_capabilities;
+    mav_array_memcpy(packet.vel, vel, sizeof(float)*3);
+    mav_array_memcpy(packet.acc, acc, sizeof(float)*3);
+    mav_array_memcpy(packet.q_target, q_target, sizeof(float)*4);
+    mav_array_memcpy(packet.rates, rates, sizeof(float)*3);
+    mav_array_memcpy(packet.position_std, position_std, sizeof(float)*2);
+    mav_array_memcpy(packet.vel_std, vel_std, sizeof(float)*3);
+    mav_array_memcpy(packet.acc_std, acc_std, sizeof(float)*3);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_TARGET_ABSOLUTE;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_TARGET_ABSOLUTE_MIN_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_CRC);
+}
+
+/**
+ * @brief Encode a target_absolute struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param target_absolute C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_target_absolute_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_target_absolute_t* target_absolute)
+{
+    return mavlink_msg_target_absolute_pack(system_id, component_id, msg, target_absolute->timestamp, target_absolute->id, target_absolute->sensor_capabilities, target_absolute->lat, target_absolute->lon, target_absolute->alt, target_absolute->vel, target_absolute->acc, target_absolute->q_target, target_absolute->rates, target_absolute->position_std, target_absolute->vel_std, target_absolute->acc_std);
+}
+
+/**
+ * @brief Encode a target_absolute struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param target_absolute C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_target_absolute_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_target_absolute_t* target_absolute)
+{
+    return mavlink_msg_target_absolute_pack_chan(system_id, component_id, chan, msg, target_absolute->timestamp, target_absolute->id, target_absolute->sensor_capabilities, target_absolute->lat, target_absolute->lon, target_absolute->alt, target_absolute->vel, target_absolute->acc, target_absolute->q_target, target_absolute->rates, target_absolute->position_std, target_absolute->vel_std, target_absolute->acc_std);
+}
+
+/**
+ * @brief Encode a target_absolute struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param target_absolute C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_target_absolute_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_target_absolute_t* target_absolute)
+{
+    return mavlink_msg_target_absolute_pack_status(system_id, component_id, _status, msg,  target_absolute->timestamp, target_absolute->id, target_absolute->sensor_capabilities, target_absolute->lat, target_absolute->lon, target_absolute->alt, target_absolute->vel, target_absolute->acc, target_absolute->q_target, target_absolute->rates, target_absolute->position_std, target_absolute->vel_std, target_absolute->acc_std);
+}
+
+/**
+ * @brief Send a target_absolute message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param timestamp [us] Timestamp (UNIX epoch time).
+ * @param id  The ID of the target if multiple targets are present
+ * @param sensor_capabilities  Bitmap to indicate the sensor's reporting capabilities
+ * @param lat [degE7] Target's latitude (WGS84)
+ * @param lon [degE7] Target's longitude (WGS84)
+ * @param alt [m] Target's altitude (AMSL)
+ * @param vel [m/s] Target's velocity in its body frame
+ * @param acc [m/s/s] Linear target's acceleration in its body frame
+ * @param q_target  Quaternion of the target's orientation from its body frame to the vehicle's NED frame.
+ * @param rates [rad/s] Target's roll, pitch and yaw rates
+ * @param position_std [m] Standard deviation of horizontal (eph) and vertical (epv) position errors
+ * @param vel_std [m/s] Standard deviation of the target's velocity in its body frame
+ * @param acc_std [m/s/s] Standard deviation of the target's acceleration in its body frame
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_target_absolute_send(mavlink_channel_t chan, uint64_t timestamp, uint8_t id, uint8_t sensor_capabilities, int32_t lat, int32_t lon, float alt, const float *vel, const float *acc, const float *q_target, const float *rates, const float *position_std, const float *vel_std, const float *acc_std)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN];
+    _mav_put_uint64_t(buf, 0, timestamp);
+    _mav_put_int32_t(buf, 8, lat);
+    _mav_put_int32_t(buf, 12, lon);
+    _mav_put_float(buf, 16, alt);
+    _mav_put_uint8_t(buf, 104, id);
+    _mav_put_uint8_t(buf, 105, sensor_capabilities);
+    _mav_put_float_array(buf, 20, vel, 3);
+    _mav_put_float_array(buf, 32, acc, 3);
+    _mav_put_float_array(buf, 44, q_target, 4);
+    _mav_put_float_array(buf, 60, rates, 3);
+    _mav_put_float_array(buf, 72, position_std, 2);
+    _mav_put_float_array(buf, 80, vel_std, 3);
+    _mav_put_float_array(buf, 92, acc_std, 3);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TARGET_ABSOLUTE, buf, MAVLINK_MSG_ID_TARGET_ABSOLUTE_MIN_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_CRC);
+#else
+    mavlink_target_absolute_t packet;
+    packet.timestamp = timestamp;
+    packet.lat = lat;
+    packet.lon = lon;
+    packet.alt = alt;
+    packet.id = id;
+    packet.sensor_capabilities = sensor_capabilities;
+    mav_array_memcpy(packet.vel, vel, sizeof(float)*3);
+    mav_array_memcpy(packet.acc, acc, sizeof(float)*3);
+    mav_array_memcpy(packet.q_target, q_target, sizeof(float)*4);
+    mav_array_memcpy(packet.rates, rates, sizeof(float)*3);
+    mav_array_memcpy(packet.position_std, position_std, sizeof(float)*2);
+    mav_array_memcpy(packet.vel_std, vel_std, sizeof(float)*3);
+    mav_array_memcpy(packet.acc_std, acc_std, sizeof(float)*3);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TARGET_ABSOLUTE, (const char *)&packet, MAVLINK_MSG_ID_TARGET_ABSOLUTE_MIN_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_CRC);
+#endif
+}
+
+/**
+ * @brief Send a target_absolute message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_target_absolute_send_struct(mavlink_channel_t chan, const mavlink_target_absolute_t* target_absolute)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_target_absolute_send(chan, target_absolute->timestamp, target_absolute->id, target_absolute->sensor_capabilities, target_absolute->lat, target_absolute->lon, target_absolute->alt, target_absolute->vel, target_absolute->acc, target_absolute->q_target, target_absolute->rates, target_absolute->position_std, target_absolute->vel_std, target_absolute->acc_std);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TARGET_ABSOLUTE, (const char *)target_absolute, MAVLINK_MSG_ID_TARGET_ABSOLUTE_MIN_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_target_absolute_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint64_t timestamp, uint8_t id, uint8_t sensor_capabilities, int32_t lat, int32_t lon, float alt, const float *vel, const float *acc, const float *q_target, const float *rates, const float *position_std, const float *vel_std, const float *acc_std)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint64_t(buf, 0, timestamp);
+    _mav_put_int32_t(buf, 8, lat);
+    _mav_put_int32_t(buf, 12, lon);
+    _mav_put_float(buf, 16, alt);
+    _mav_put_uint8_t(buf, 104, id);
+    _mav_put_uint8_t(buf, 105, sensor_capabilities);
+    _mav_put_float_array(buf, 20, vel, 3);
+    _mav_put_float_array(buf, 32, acc, 3);
+    _mav_put_float_array(buf, 44, q_target, 4);
+    _mav_put_float_array(buf, 60, rates, 3);
+    _mav_put_float_array(buf, 72, position_std, 2);
+    _mav_put_float_array(buf, 80, vel_std, 3);
+    _mav_put_float_array(buf, 92, acc_std, 3);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TARGET_ABSOLUTE, buf, MAVLINK_MSG_ID_TARGET_ABSOLUTE_MIN_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_CRC);
+#else
+    mavlink_target_absolute_t *packet = (mavlink_target_absolute_t *)msgbuf;
+    packet->timestamp = timestamp;
+    packet->lat = lat;
+    packet->lon = lon;
+    packet->alt = alt;
+    packet->id = id;
+    packet->sensor_capabilities = sensor_capabilities;
+    mav_array_memcpy(packet->vel, vel, sizeof(float)*3);
+    mav_array_memcpy(packet->acc, acc, sizeof(float)*3);
+    mav_array_memcpy(packet->q_target, q_target, sizeof(float)*4);
+    mav_array_memcpy(packet->rates, rates, sizeof(float)*3);
+    mav_array_memcpy(packet->position_std, position_std, sizeof(float)*2);
+    mav_array_memcpy(packet->vel_std, vel_std, sizeof(float)*3);
+    mav_array_memcpy(packet->acc_std, acc_std, sizeof(float)*3);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TARGET_ABSOLUTE, (const char *)packet, MAVLINK_MSG_ID_TARGET_ABSOLUTE_MIN_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN, MAVLINK_MSG_ID_TARGET_ABSOLUTE_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE TARGET_ABSOLUTE UNPACKING
+
+
+/**
+ * @brief Get field timestamp from target_absolute message
+ *
+ * @return [us] Timestamp (UNIX epoch time).
+ */
+static inline uint64_t mavlink_msg_target_absolute_get_timestamp(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint64_t(msg,  0);
+}
+
+/**
+ * @brief Get field id from target_absolute message
+ *
+ * @return  The ID of the target if multiple targets are present
+ */
+static inline uint8_t mavlink_msg_target_absolute_get_id(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  104);
+}
+
+/**
+ * @brief Get field sensor_capabilities from target_absolute message
+ *
+ * @return  Bitmap to indicate the sensor's reporting capabilities
+ */
+static inline uint8_t mavlink_msg_target_absolute_get_sensor_capabilities(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  105);
+}
+
+/**
+ * @brief Get field lat from target_absolute message
+ *
+ * @return [degE7] Target's latitude (WGS84)
+ */
+static inline int32_t mavlink_msg_target_absolute_get_lat(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  8);
+}
+
+/**
+ * @brief Get field lon from target_absolute message
+ *
+ * @return [degE7] Target's longitude (WGS84)
+ */
+static inline int32_t mavlink_msg_target_absolute_get_lon(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_int32_t(msg,  12);
+}
+
+/**
+ * @brief Get field alt from target_absolute message
+ *
+ * @return [m] Target's altitude (AMSL)
+ */
+static inline float mavlink_msg_target_absolute_get_alt(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  16);
+}
+
+/**
+ * @brief Get field vel from target_absolute message
+ *
+ * @return [m/s] Target's velocity in its body frame
+ */
+static inline uint16_t mavlink_msg_target_absolute_get_vel(const mavlink_message_t* msg, float *vel)
+{
+    return _MAV_RETURN_float_array(msg, vel, 3,  20);
+}
+
+/**
+ * @brief Get field acc from target_absolute message
+ *
+ * @return [m/s/s] Linear target's acceleration in its body frame
+ */
+static inline uint16_t mavlink_msg_target_absolute_get_acc(const mavlink_message_t* msg, float *acc)
+{
+    return _MAV_RETURN_float_array(msg, acc, 3,  32);
+}
+
+/**
+ * @brief Get field q_target from target_absolute message
+ *
+ * @return  Quaternion of the target's orientation from its body frame to the vehicle's NED frame.
+ */
+static inline uint16_t mavlink_msg_target_absolute_get_q_target(const mavlink_message_t* msg, float *q_target)
+{
+    return _MAV_RETURN_float_array(msg, q_target, 4,  44);
+}
+
+/**
+ * @brief Get field rates from target_absolute message
+ *
+ * @return [rad/s] Target's roll, pitch and yaw rates
+ */
+static inline uint16_t mavlink_msg_target_absolute_get_rates(const mavlink_message_t* msg, float *rates)
+{
+    return _MAV_RETURN_float_array(msg, rates, 3,  60);
+}
+
+/**
+ * @brief Get field position_std from target_absolute message
+ *
+ * @return [m] Standard deviation of horizontal (eph) and vertical (epv) position errors
+ */
+static inline uint16_t mavlink_msg_target_absolute_get_position_std(const mavlink_message_t* msg, float *position_std)
+{
+    return _MAV_RETURN_float_array(msg, position_std, 2,  72);
+}
+
+/**
+ * @brief Get field vel_std from target_absolute message
+ *
+ * @return [m/s] Standard deviation of the target's velocity in its body frame
+ */
+static inline uint16_t mavlink_msg_target_absolute_get_vel_std(const mavlink_message_t* msg, float *vel_std)
+{
+    return _MAV_RETURN_float_array(msg, vel_std, 3,  80);
+}
+
+/**
+ * @brief Get field acc_std from target_absolute message
+ *
+ * @return [m/s/s] Standard deviation of the target's acceleration in its body frame
+ */
+static inline uint16_t mavlink_msg_target_absolute_get_acc_std(const mavlink_message_t* msg, float *acc_std)
+{
+    return _MAV_RETURN_float_array(msg, acc_std, 3,  92);
+}
+
+/**
+ * @brief Decode a target_absolute message into a struct
+ *
+ * @param msg The message to decode
+ * @param target_absolute C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_target_absolute_decode(const mavlink_message_t* msg, mavlink_target_absolute_t* target_absolute)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    target_absolute->timestamp = mavlink_msg_target_absolute_get_timestamp(msg);
+    target_absolute->lat = mavlink_msg_target_absolute_get_lat(msg);
+    target_absolute->lon = mavlink_msg_target_absolute_get_lon(msg);
+    target_absolute->alt = mavlink_msg_target_absolute_get_alt(msg);
+    mavlink_msg_target_absolute_get_vel(msg, target_absolute->vel);
+    mavlink_msg_target_absolute_get_acc(msg, target_absolute->acc);
+    mavlink_msg_target_absolute_get_q_target(msg, target_absolute->q_target);
+    mavlink_msg_target_absolute_get_rates(msg, target_absolute->rates);
+    mavlink_msg_target_absolute_get_position_std(msg, target_absolute->position_std);
+    mavlink_msg_target_absolute_get_vel_std(msg, target_absolute->vel_std);
+    mavlink_msg_target_absolute_get_acc_std(msg, target_absolute->acc_std);
+    target_absolute->id = mavlink_msg_target_absolute_get_id(msg);
+    target_absolute->sensor_capabilities = mavlink_msg_target_absolute_get_sensor_capabilities(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN? msg->len : MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN;
+        memset(target_absolute, 0, MAVLINK_MSG_ID_TARGET_ABSOLUTE_LEN);
+    memcpy(target_absolute, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_target_relative.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_target_relative.h
@@ -1,0 +1,532 @@
+#pragma once
+// MESSAGE TARGET_RELATIVE PACKING
+
+#define MAVLINK_MSG_ID_TARGET_RELATIVE 511
+
+
+typedef struct __mavlink_target_relative_t {
+ uint64_t timestamp; /*< [us] Timestamp (UNIX epoch time)*/
+ float x; /*< [m] X Position of the target in TARGET_OBS_FRAME*/
+ float y; /*< [m] Y Position of the target in TARGET_OBS_FRAME*/
+ float z; /*< [m] Z Position of the target in TARGET_OBS_FRAME*/
+ float pos_std[3]; /*< [m] Standard deviation of the target's position in TARGET_OBS_FRAME*/
+ float yaw_std; /*< [rad] Standard deviation of the target's orientation in TARGET_OBS_FRAME*/
+ float q_target[4]; /*<  Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)*/
+ float q_sensor[4]; /*<  Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)*/
+ uint8_t id; /*<  The ID of the target if multiple targets are present*/
+ uint8_t frame; /*<  Coordinate frame used for following fields.*/
+ uint8_t type; /*<  Type of target*/
+} mavlink_target_relative_t;
+
+#define MAVLINK_MSG_ID_TARGET_RELATIVE_LEN 71
+#define MAVLINK_MSG_ID_TARGET_RELATIVE_MIN_LEN 71
+#define MAVLINK_MSG_ID_511_LEN 71
+#define MAVLINK_MSG_ID_511_MIN_LEN 71
+
+#define MAVLINK_MSG_ID_TARGET_RELATIVE_CRC 28
+#define MAVLINK_MSG_ID_511_CRC 28
+
+#define MAVLINK_MSG_TARGET_RELATIVE_FIELD_POS_STD_LEN 3
+#define MAVLINK_MSG_TARGET_RELATIVE_FIELD_Q_TARGET_LEN 4
+#define MAVLINK_MSG_TARGET_RELATIVE_FIELD_Q_SENSOR_LEN 4
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_TARGET_RELATIVE { \
+    511, \
+    "TARGET_RELATIVE", \
+    11, \
+    {  { "timestamp", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_target_relative_t, timestamp) }, \
+         { "id", NULL, MAVLINK_TYPE_UINT8_T, 0, 68, offsetof(mavlink_target_relative_t, id) }, \
+         { "frame", NULL, MAVLINK_TYPE_UINT8_T, 0, 69, offsetof(mavlink_target_relative_t, frame) }, \
+         { "x", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_target_relative_t, x) }, \
+         { "y", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_target_relative_t, y) }, \
+         { "z", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_target_relative_t, z) }, \
+         { "pos_std", NULL, MAVLINK_TYPE_FLOAT, 3, 20, offsetof(mavlink_target_relative_t, pos_std) }, \
+         { "yaw_std", NULL, MAVLINK_TYPE_FLOAT, 0, 32, offsetof(mavlink_target_relative_t, yaw_std) }, \
+         { "q_target", NULL, MAVLINK_TYPE_FLOAT, 4, 36, offsetof(mavlink_target_relative_t, q_target) }, \
+         { "q_sensor", NULL, MAVLINK_TYPE_FLOAT, 4, 52, offsetof(mavlink_target_relative_t, q_sensor) }, \
+         { "type", NULL, MAVLINK_TYPE_UINT8_T, 0, 70, offsetof(mavlink_target_relative_t, type) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_TARGET_RELATIVE { \
+    "TARGET_RELATIVE", \
+    11, \
+    {  { "timestamp", NULL, MAVLINK_TYPE_UINT64_T, 0, 0, offsetof(mavlink_target_relative_t, timestamp) }, \
+         { "id", NULL, MAVLINK_TYPE_UINT8_T, 0, 68, offsetof(mavlink_target_relative_t, id) }, \
+         { "frame", NULL, MAVLINK_TYPE_UINT8_T, 0, 69, offsetof(mavlink_target_relative_t, frame) }, \
+         { "x", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_target_relative_t, x) }, \
+         { "y", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_target_relative_t, y) }, \
+         { "z", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_target_relative_t, z) }, \
+         { "pos_std", NULL, MAVLINK_TYPE_FLOAT, 3, 20, offsetof(mavlink_target_relative_t, pos_std) }, \
+         { "yaw_std", NULL, MAVLINK_TYPE_FLOAT, 0, 32, offsetof(mavlink_target_relative_t, yaw_std) }, \
+         { "q_target", NULL, MAVLINK_TYPE_FLOAT, 4, 36, offsetof(mavlink_target_relative_t, q_target) }, \
+         { "q_sensor", NULL, MAVLINK_TYPE_FLOAT, 4, 52, offsetof(mavlink_target_relative_t, q_sensor) }, \
+         { "type", NULL, MAVLINK_TYPE_UINT8_T, 0, 70, offsetof(mavlink_target_relative_t, type) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a target_relative message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param timestamp [us] Timestamp (UNIX epoch time)
+ * @param id  The ID of the target if multiple targets are present
+ * @param frame  Coordinate frame used for following fields.
+ * @param x [m] X Position of the target in TARGET_OBS_FRAME
+ * @param y [m] Y Position of the target in TARGET_OBS_FRAME
+ * @param z [m] Z Position of the target in TARGET_OBS_FRAME
+ * @param pos_std [m] Standard deviation of the target's position in TARGET_OBS_FRAME
+ * @param yaw_std [rad] Standard deviation of the target's orientation in TARGET_OBS_FRAME
+ * @param q_target  Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+ * @param q_sensor  Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+ * @param type  Type of target
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_target_relative_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint64_t timestamp, uint8_t id, uint8_t frame, float x, float y, float z, const float *pos_std, float yaw_std, const float *q_target, const float *q_sensor, uint8_t type)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TARGET_RELATIVE_LEN];
+    _mav_put_uint64_t(buf, 0, timestamp);
+    _mav_put_float(buf, 8, x);
+    _mav_put_float(buf, 12, y);
+    _mav_put_float(buf, 16, z);
+    _mav_put_float(buf, 32, yaw_std);
+    _mav_put_uint8_t(buf, 68, id);
+    _mav_put_uint8_t(buf, 69, frame);
+    _mav_put_uint8_t(buf, 70, type);
+    _mav_put_float_array(buf, 20, pos_std, 3);
+    _mav_put_float_array(buf, 36, q_target, 4);
+    _mav_put_float_array(buf, 52, q_sensor, 4);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN);
+#else
+    mavlink_target_relative_t packet;
+    packet.timestamp = timestamp;
+    packet.x = x;
+    packet.y = y;
+    packet.z = z;
+    packet.yaw_std = yaw_std;
+    packet.id = id;
+    packet.frame = frame;
+    packet.type = type;
+    mav_array_memcpy(packet.pos_std, pos_std, sizeof(float)*3);
+    mav_array_memcpy(packet.q_target, q_target, sizeof(float)*4);
+    mav_array_memcpy(packet.q_sensor, q_sensor, sizeof(float)*4);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_TARGET_RELATIVE;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_TARGET_RELATIVE_MIN_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_CRC);
+}
+
+/**
+ * @brief Pack a target_relative message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param timestamp [us] Timestamp (UNIX epoch time)
+ * @param id  The ID of the target if multiple targets are present
+ * @param frame  Coordinate frame used for following fields.
+ * @param x [m] X Position of the target in TARGET_OBS_FRAME
+ * @param y [m] Y Position of the target in TARGET_OBS_FRAME
+ * @param z [m] Z Position of the target in TARGET_OBS_FRAME
+ * @param pos_std [m] Standard deviation of the target's position in TARGET_OBS_FRAME
+ * @param yaw_std [rad] Standard deviation of the target's orientation in TARGET_OBS_FRAME
+ * @param q_target  Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+ * @param q_sensor  Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+ * @param type  Type of target
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_target_relative_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint64_t timestamp, uint8_t id, uint8_t frame, float x, float y, float z, const float *pos_std, float yaw_std, const float *q_target, const float *q_sensor, uint8_t type)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TARGET_RELATIVE_LEN];
+    _mav_put_uint64_t(buf, 0, timestamp);
+    _mav_put_float(buf, 8, x);
+    _mav_put_float(buf, 12, y);
+    _mav_put_float(buf, 16, z);
+    _mav_put_float(buf, 32, yaw_std);
+    _mav_put_uint8_t(buf, 68, id);
+    _mav_put_uint8_t(buf, 69, frame);
+    _mav_put_uint8_t(buf, 70, type);
+    _mav_put_float_array(buf, 20, pos_std, 3);
+    _mav_put_float_array(buf, 36, q_target, 4);
+    _mav_put_float_array(buf, 52, q_sensor, 4);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN);
+#else
+    mavlink_target_relative_t packet;
+    packet.timestamp = timestamp;
+    packet.x = x;
+    packet.y = y;
+    packet.z = z;
+    packet.yaw_std = yaw_std;
+    packet.id = id;
+    packet.frame = frame;
+    packet.type = type;
+    mav_array_memcpy(packet.pos_std, pos_std, sizeof(float)*3);
+    mav_array_memcpy(packet.q_target, q_target, sizeof(float)*4);
+    mav_array_memcpy(packet.q_sensor, q_sensor, sizeof(float)*4);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_TARGET_RELATIVE;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_TARGET_RELATIVE_MIN_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_TARGET_RELATIVE_MIN_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a target_relative message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param timestamp [us] Timestamp (UNIX epoch time)
+ * @param id  The ID of the target if multiple targets are present
+ * @param frame  Coordinate frame used for following fields.
+ * @param x [m] X Position of the target in TARGET_OBS_FRAME
+ * @param y [m] Y Position of the target in TARGET_OBS_FRAME
+ * @param z [m] Z Position of the target in TARGET_OBS_FRAME
+ * @param pos_std [m] Standard deviation of the target's position in TARGET_OBS_FRAME
+ * @param yaw_std [rad] Standard deviation of the target's orientation in TARGET_OBS_FRAME
+ * @param q_target  Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+ * @param q_sensor  Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+ * @param type  Type of target
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_target_relative_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint64_t timestamp,uint8_t id,uint8_t frame,float x,float y,float z,const float *pos_std,float yaw_std,const float *q_target,const float *q_sensor,uint8_t type)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TARGET_RELATIVE_LEN];
+    _mav_put_uint64_t(buf, 0, timestamp);
+    _mav_put_float(buf, 8, x);
+    _mav_put_float(buf, 12, y);
+    _mav_put_float(buf, 16, z);
+    _mav_put_float(buf, 32, yaw_std);
+    _mav_put_uint8_t(buf, 68, id);
+    _mav_put_uint8_t(buf, 69, frame);
+    _mav_put_uint8_t(buf, 70, type);
+    _mav_put_float_array(buf, 20, pos_std, 3);
+    _mav_put_float_array(buf, 36, q_target, 4);
+    _mav_put_float_array(buf, 52, q_sensor, 4);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN);
+#else
+    mavlink_target_relative_t packet;
+    packet.timestamp = timestamp;
+    packet.x = x;
+    packet.y = y;
+    packet.z = z;
+    packet.yaw_std = yaw_std;
+    packet.id = id;
+    packet.frame = frame;
+    packet.type = type;
+    mav_array_memcpy(packet.pos_std, pos_std, sizeof(float)*3);
+    mav_array_memcpy(packet.q_target, q_target, sizeof(float)*4);
+    mav_array_memcpy(packet.q_sensor, q_sensor, sizeof(float)*4);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_TARGET_RELATIVE;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_TARGET_RELATIVE_MIN_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_CRC);
+}
+
+/**
+ * @brief Encode a target_relative struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param target_relative C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_target_relative_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_target_relative_t* target_relative)
+{
+    return mavlink_msg_target_relative_pack(system_id, component_id, msg, target_relative->timestamp, target_relative->id, target_relative->frame, target_relative->x, target_relative->y, target_relative->z, target_relative->pos_std, target_relative->yaw_std, target_relative->q_target, target_relative->q_sensor, target_relative->type);
+}
+
+/**
+ * @brief Encode a target_relative struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param target_relative C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_target_relative_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_target_relative_t* target_relative)
+{
+    return mavlink_msg_target_relative_pack_chan(system_id, component_id, chan, msg, target_relative->timestamp, target_relative->id, target_relative->frame, target_relative->x, target_relative->y, target_relative->z, target_relative->pos_std, target_relative->yaw_std, target_relative->q_target, target_relative->q_sensor, target_relative->type);
+}
+
+/**
+ * @brief Encode a target_relative struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param target_relative C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_target_relative_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_target_relative_t* target_relative)
+{
+    return mavlink_msg_target_relative_pack_status(system_id, component_id, _status, msg,  target_relative->timestamp, target_relative->id, target_relative->frame, target_relative->x, target_relative->y, target_relative->z, target_relative->pos_std, target_relative->yaw_std, target_relative->q_target, target_relative->q_sensor, target_relative->type);
+}
+
+/**
+ * @brief Send a target_relative message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param timestamp [us] Timestamp (UNIX epoch time)
+ * @param id  The ID of the target if multiple targets are present
+ * @param frame  Coordinate frame used for following fields.
+ * @param x [m] X Position of the target in TARGET_OBS_FRAME
+ * @param y [m] Y Position of the target in TARGET_OBS_FRAME
+ * @param z [m] Z Position of the target in TARGET_OBS_FRAME
+ * @param pos_std [m] Standard deviation of the target's position in TARGET_OBS_FRAME
+ * @param yaw_std [rad] Standard deviation of the target's orientation in TARGET_OBS_FRAME
+ * @param q_target  Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+ * @param q_sensor  Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+ * @param type  Type of target
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_target_relative_send(mavlink_channel_t chan, uint64_t timestamp, uint8_t id, uint8_t frame, float x, float y, float z, const float *pos_std, float yaw_std, const float *q_target, const float *q_sensor, uint8_t type)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TARGET_RELATIVE_LEN];
+    _mav_put_uint64_t(buf, 0, timestamp);
+    _mav_put_float(buf, 8, x);
+    _mav_put_float(buf, 12, y);
+    _mav_put_float(buf, 16, z);
+    _mav_put_float(buf, 32, yaw_std);
+    _mav_put_uint8_t(buf, 68, id);
+    _mav_put_uint8_t(buf, 69, frame);
+    _mav_put_uint8_t(buf, 70, type);
+    _mav_put_float_array(buf, 20, pos_std, 3);
+    _mav_put_float_array(buf, 36, q_target, 4);
+    _mav_put_float_array(buf, 52, q_sensor, 4);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TARGET_RELATIVE, buf, MAVLINK_MSG_ID_TARGET_RELATIVE_MIN_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_CRC);
+#else
+    mavlink_target_relative_t packet;
+    packet.timestamp = timestamp;
+    packet.x = x;
+    packet.y = y;
+    packet.z = z;
+    packet.yaw_std = yaw_std;
+    packet.id = id;
+    packet.frame = frame;
+    packet.type = type;
+    mav_array_memcpy(packet.pos_std, pos_std, sizeof(float)*3);
+    mav_array_memcpy(packet.q_target, q_target, sizeof(float)*4);
+    mav_array_memcpy(packet.q_sensor, q_sensor, sizeof(float)*4);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TARGET_RELATIVE, (const char *)&packet, MAVLINK_MSG_ID_TARGET_RELATIVE_MIN_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_CRC);
+#endif
+}
+
+/**
+ * @brief Send a target_relative message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_target_relative_send_struct(mavlink_channel_t chan, const mavlink_target_relative_t* target_relative)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_target_relative_send(chan, target_relative->timestamp, target_relative->id, target_relative->frame, target_relative->x, target_relative->y, target_relative->z, target_relative->pos_std, target_relative->yaw_std, target_relative->q_target, target_relative->q_sensor, target_relative->type);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TARGET_RELATIVE, (const char *)target_relative, MAVLINK_MSG_ID_TARGET_RELATIVE_MIN_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_TARGET_RELATIVE_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_target_relative_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint64_t timestamp, uint8_t id, uint8_t frame, float x, float y, float z, const float *pos_std, float yaw_std, const float *q_target, const float *q_sensor, uint8_t type)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint64_t(buf, 0, timestamp);
+    _mav_put_float(buf, 8, x);
+    _mav_put_float(buf, 12, y);
+    _mav_put_float(buf, 16, z);
+    _mav_put_float(buf, 32, yaw_std);
+    _mav_put_uint8_t(buf, 68, id);
+    _mav_put_uint8_t(buf, 69, frame);
+    _mav_put_uint8_t(buf, 70, type);
+    _mav_put_float_array(buf, 20, pos_std, 3);
+    _mav_put_float_array(buf, 36, q_target, 4);
+    _mav_put_float_array(buf, 52, q_sensor, 4);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TARGET_RELATIVE, buf, MAVLINK_MSG_ID_TARGET_RELATIVE_MIN_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_CRC);
+#else
+    mavlink_target_relative_t *packet = (mavlink_target_relative_t *)msgbuf;
+    packet->timestamp = timestamp;
+    packet->x = x;
+    packet->y = y;
+    packet->z = z;
+    packet->yaw_std = yaw_std;
+    packet->id = id;
+    packet->frame = frame;
+    packet->type = type;
+    mav_array_memcpy(packet->pos_std, pos_std, sizeof(float)*3);
+    mav_array_memcpy(packet->q_target, q_target, sizeof(float)*4);
+    mav_array_memcpy(packet->q_sensor, q_sensor, sizeof(float)*4);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TARGET_RELATIVE, (const char *)packet, MAVLINK_MSG_ID_TARGET_RELATIVE_MIN_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN, MAVLINK_MSG_ID_TARGET_RELATIVE_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE TARGET_RELATIVE UNPACKING
+
+
+/**
+ * @brief Get field timestamp from target_relative message
+ *
+ * @return [us] Timestamp (UNIX epoch time)
+ */
+static inline uint64_t mavlink_msg_target_relative_get_timestamp(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint64_t(msg,  0);
+}
+
+/**
+ * @brief Get field id from target_relative message
+ *
+ * @return  The ID of the target if multiple targets are present
+ */
+static inline uint8_t mavlink_msg_target_relative_get_id(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  68);
+}
+
+/**
+ * @brief Get field frame from target_relative message
+ *
+ * @return  Coordinate frame used for following fields.
+ */
+static inline uint8_t mavlink_msg_target_relative_get_frame(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  69);
+}
+
+/**
+ * @brief Get field x from target_relative message
+ *
+ * @return [m] X Position of the target in TARGET_OBS_FRAME
+ */
+static inline float mavlink_msg_target_relative_get_x(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  8);
+}
+
+/**
+ * @brief Get field y from target_relative message
+ *
+ * @return [m] Y Position of the target in TARGET_OBS_FRAME
+ */
+static inline float mavlink_msg_target_relative_get_y(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  12);
+}
+
+/**
+ * @brief Get field z from target_relative message
+ *
+ * @return [m] Z Position of the target in TARGET_OBS_FRAME
+ */
+static inline float mavlink_msg_target_relative_get_z(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  16);
+}
+
+/**
+ * @brief Get field pos_std from target_relative message
+ *
+ * @return [m] Standard deviation of the target's position in TARGET_OBS_FRAME
+ */
+static inline uint16_t mavlink_msg_target_relative_get_pos_std(const mavlink_message_t* msg, float *pos_std)
+{
+    return _MAV_RETURN_float_array(msg, pos_std, 3,  20);
+}
+
+/**
+ * @brief Get field yaw_std from target_relative message
+ *
+ * @return [rad] Standard deviation of the target's orientation in TARGET_OBS_FRAME
+ */
+static inline float mavlink_msg_target_relative_get_yaw_std(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  32);
+}
+
+/**
+ * @brief Get field q_target from target_relative message
+ *
+ * @return  Quaternion of the target's orientation from the target's frame to the TARGET_OBS_FRAME (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+ */
+static inline uint16_t mavlink_msg_target_relative_get_q_target(const mavlink_message_t* msg, float *q_target)
+{
+    return _MAV_RETURN_float_array(msg, q_target, 4,  36);
+}
+
+/**
+ * @brief Get field q_sensor from target_relative message
+ *
+ * @return  Quaternion of the sensor's orientation from TARGET_OBS_FRAME to vehicle-carried NED. (Ignored if set to (0,0,0,0)) (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+ */
+static inline uint16_t mavlink_msg_target_relative_get_q_sensor(const mavlink_message_t* msg, float *q_sensor)
+{
+    return _MAV_RETURN_float_array(msg, q_sensor, 4,  52);
+}
+
+/**
+ * @brief Get field type from target_relative message
+ *
+ * @return  Type of target
+ */
+static inline uint8_t mavlink_msg_target_relative_get_type(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  70);
+}
+
+/**
+ * @brief Decode a target_relative message into a struct
+ *
+ * @param msg The message to decode
+ * @param target_relative C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_target_relative_decode(const mavlink_message_t* msg, mavlink_target_relative_t* target_relative)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    target_relative->timestamp = mavlink_msg_target_relative_get_timestamp(msg);
+    target_relative->x = mavlink_msg_target_relative_get_x(msg);
+    target_relative->y = mavlink_msg_target_relative_get_y(msg);
+    target_relative->z = mavlink_msg_target_relative_get_z(msg);
+    mavlink_msg_target_relative_get_pos_std(msg, target_relative->pos_std);
+    target_relative->yaw_std = mavlink_msg_target_relative_get_yaw_std(msg);
+    mavlink_msg_target_relative_get_q_target(msg, target_relative->q_target);
+    mavlink_msg_target_relative_get_q_sensor(msg, target_relative->q_sensor);
+    target_relative->id = mavlink_msg_target_relative_get_id(msg);
+    target_relative->frame = mavlink_msg_target_relative_get_frame(msg);
+    target_relative->type = mavlink_msg_target_relative_get_type(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_TARGET_RELATIVE_LEN? msg->len : MAVLINK_MSG_ID_TARGET_RELATIVE_LEN;
+        memset(target_relative, 0, MAVLINK_MSG_ID_TARGET_RELATIVE_LEN);
+    memcpy(target_relative, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_tilt_angle.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_tilt_angle.h
@@ -1,0 +1,372 @@
+#pragma once
+// MESSAGE TILT_ANGLE PACKING
+
+#define MAVLINK_MSG_ID_TILT_ANGLE 513
+
+
+typedef struct __mavlink_tilt_angle_t {
+ uint32_t time_boot_ms; /*< [ms] Timestamp (time since system boot).*/
+ float tilt_fl; /*< [deg] Front left tilt angle*/
+ float tilt_fr; /*< [deg] Front right tilt angle*/
+ float tilt_rl; /*< [deg] Right left tilt angle*/
+ float tilt_rr; /*< [deg] Right right tilt angle*/
+} mavlink_tilt_angle_t;
+
+#define MAVLINK_MSG_ID_TILT_ANGLE_LEN 20
+#define MAVLINK_MSG_ID_TILT_ANGLE_MIN_LEN 20
+#define MAVLINK_MSG_ID_513_LEN 20
+#define MAVLINK_MSG_ID_513_MIN_LEN 20
+
+#define MAVLINK_MSG_ID_TILT_ANGLE_CRC 130
+#define MAVLINK_MSG_ID_513_CRC 130
+
+
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_TILT_ANGLE { \
+    513, \
+    "TILT_ANGLE", \
+    5, \
+    {  { "time_boot_ms", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_tilt_angle_t, time_boot_ms) }, \
+         { "tilt_fl", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_tilt_angle_t, tilt_fl) }, \
+         { "tilt_fr", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_tilt_angle_t, tilt_fr) }, \
+         { "tilt_rl", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_tilt_angle_t, tilt_rl) }, \
+         { "tilt_rr", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_tilt_angle_t, tilt_rr) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_TILT_ANGLE { \
+    "TILT_ANGLE", \
+    5, \
+    {  { "time_boot_ms", NULL, MAVLINK_TYPE_UINT32_T, 0, 0, offsetof(mavlink_tilt_angle_t, time_boot_ms) }, \
+         { "tilt_fl", NULL, MAVLINK_TYPE_FLOAT, 0, 4, offsetof(mavlink_tilt_angle_t, tilt_fl) }, \
+         { "tilt_fr", NULL, MAVLINK_TYPE_FLOAT, 0, 8, offsetof(mavlink_tilt_angle_t, tilt_fr) }, \
+         { "tilt_rl", NULL, MAVLINK_TYPE_FLOAT, 0, 12, offsetof(mavlink_tilt_angle_t, tilt_rl) }, \
+         { "tilt_rr", NULL, MAVLINK_TYPE_FLOAT, 0, 16, offsetof(mavlink_tilt_angle_t, tilt_rr) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a tilt_angle message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param tilt_fl [deg] Front left tilt angle
+ * @param tilt_fr [deg] Front right tilt angle
+ * @param tilt_rl [deg] Right left tilt angle
+ * @param tilt_rr [deg] Right right tilt angle
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_tilt_angle_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               uint32_t time_boot_ms, float tilt_fl, float tilt_fr, float tilt_rl, float tilt_rr)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TILT_ANGLE_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, tilt_fl);
+    _mav_put_float(buf, 8, tilt_fr);
+    _mav_put_float(buf, 12, tilt_rl);
+    _mav_put_float(buf, 16, tilt_rr);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_TILT_ANGLE_LEN);
+#else
+    mavlink_tilt_angle_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.tilt_fl = tilt_fl;
+    packet.tilt_fr = tilt_fr;
+    packet.tilt_rl = tilt_rl;
+    packet.tilt_rr = tilt_rr;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_TILT_ANGLE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_TILT_ANGLE;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_TILT_ANGLE_MIN_LEN, MAVLINK_MSG_ID_TILT_ANGLE_LEN, MAVLINK_MSG_ID_TILT_ANGLE_CRC);
+}
+
+/**
+ * @brief Pack a tilt_angle message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param tilt_fl [deg] Front left tilt angle
+ * @param tilt_fr [deg] Front right tilt angle
+ * @param tilt_rl [deg] Right left tilt angle
+ * @param tilt_rr [deg] Right right tilt angle
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_tilt_angle_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               uint32_t time_boot_ms, float tilt_fl, float tilt_fr, float tilt_rl, float tilt_rr)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TILT_ANGLE_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, tilt_fl);
+    _mav_put_float(buf, 8, tilt_fr);
+    _mav_put_float(buf, 12, tilt_rl);
+    _mav_put_float(buf, 16, tilt_rr);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_TILT_ANGLE_LEN);
+#else
+    mavlink_tilt_angle_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.tilt_fl = tilt_fl;
+    packet.tilt_fr = tilt_fr;
+    packet.tilt_rl = tilt_rl;
+    packet.tilt_rr = tilt_rr;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_TILT_ANGLE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_TILT_ANGLE;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_TILT_ANGLE_MIN_LEN, MAVLINK_MSG_ID_TILT_ANGLE_LEN, MAVLINK_MSG_ID_TILT_ANGLE_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_TILT_ANGLE_MIN_LEN, MAVLINK_MSG_ID_TILT_ANGLE_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a tilt_angle message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param tilt_fl [deg] Front left tilt angle
+ * @param tilt_fr [deg] Front right tilt angle
+ * @param tilt_rl [deg] Right left tilt angle
+ * @param tilt_rr [deg] Right right tilt angle
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_tilt_angle_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   uint32_t time_boot_ms,float tilt_fl,float tilt_fr,float tilt_rl,float tilt_rr)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TILT_ANGLE_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, tilt_fl);
+    _mav_put_float(buf, 8, tilt_fr);
+    _mav_put_float(buf, 12, tilt_rl);
+    _mav_put_float(buf, 16, tilt_rr);
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_TILT_ANGLE_LEN);
+#else
+    mavlink_tilt_angle_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.tilt_fl = tilt_fl;
+    packet.tilt_fr = tilt_fr;
+    packet.tilt_rl = tilt_rl;
+    packet.tilt_rr = tilt_rr;
+
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_TILT_ANGLE_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_TILT_ANGLE;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_TILT_ANGLE_MIN_LEN, MAVLINK_MSG_ID_TILT_ANGLE_LEN, MAVLINK_MSG_ID_TILT_ANGLE_CRC);
+}
+
+/**
+ * @brief Encode a tilt_angle struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param tilt_angle C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_tilt_angle_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_tilt_angle_t* tilt_angle)
+{
+    return mavlink_msg_tilt_angle_pack(system_id, component_id, msg, tilt_angle->time_boot_ms, tilt_angle->tilt_fl, tilt_angle->tilt_fr, tilt_angle->tilt_rl, tilt_angle->tilt_rr);
+}
+
+/**
+ * @brief Encode a tilt_angle struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param tilt_angle C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_tilt_angle_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_tilt_angle_t* tilt_angle)
+{
+    return mavlink_msg_tilt_angle_pack_chan(system_id, component_id, chan, msg, tilt_angle->time_boot_ms, tilt_angle->tilt_fl, tilt_angle->tilt_fr, tilt_angle->tilt_rl, tilt_angle->tilt_rr);
+}
+
+/**
+ * @brief Encode a tilt_angle struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param tilt_angle C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_tilt_angle_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_tilt_angle_t* tilt_angle)
+{
+    return mavlink_msg_tilt_angle_pack_status(system_id, component_id, _status, msg,  tilt_angle->time_boot_ms, tilt_angle->tilt_fl, tilt_angle->tilt_fr, tilt_angle->tilt_rl, tilt_angle->tilt_rr);
+}
+
+/**
+ * @brief Send a tilt_angle message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param time_boot_ms [ms] Timestamp (time since system boot).
+ * @param tilt_fl [deg] Front left tilt angle
+ * @param tilt_fr [deg] Front right tilt angle
+ * @param tilt_rl [deg] Right left tilt angle
+ * @param tilt_rr [deg] Right right tilt angle
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_tilt_angle_send(mavlink_channel_t chan, uint32_t time_boot_ms, float tilt_fl, float tilt_fr, float tilt_rl, float tilt_rr)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_TILT_ANGLE_LEN];
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, tilt_fl);
+    _mav_put_float(buf, 8, tilt_fr);
+    _mav_put_float(buf, 12, tilt_rl);
+    _mav_put_float(buf, 16, tilt_rr);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TILT_ANGLE, buf, MAVLINK_MSG_ID_TILT_ANGLE_MIN_LEN, MAVLINK_MSG_ID_TILT_ANGLE_LEN, MAVLINK_MSG_ID_TILT_ANGLE_CRC);
+#else
+    mavlink_tilt_angle_t packet;
+    packet.time_boot_ms = time_boot_ms;
+    packet.tilt_fl = tilt_fl;
+    packet.tilt_fr = tilt_fr;
+    packet.tilt_rl = tilt_rl;
+    packet.tilt_rr = tilt_rr;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TILT_ANGLE, (const char *)&packet, MAVLINK_MSG_ID_TILT_ANGLE_MIN_LEN, MAVLINK_MSG_ID_TILT_ANGLE_LEN, MAVLINK_MSG_ID_TILT_ANGLE_CRC);
+#endif
+}
+
+/**
+ * @brief Send a tilt_angle message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_tilt_angle_send_struct(mavlink_channel_t chan, const mavlink_tilt_angle_t* tilt_angle)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_tilt_angle_send(chan, tilt_angle->time_boot_ms, tilt_angle->tilt_fl, tilt_angle->tilt_fr, tilt_angle->tilt_rl, tilt_angle->tilt_rr);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TILT_ANGLE, (const char *)tilt_angle, MAVLINK_MSG_ID_TILT_ANGLE_MIN_LEN, MAVLINK_MSG_ID_TILT_ANGLE_LEN, MAVLINK_MSG_ID_TILT_ANGLE_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_TILT_ANGLE_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_tilt_angle_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  uint32_t time_boot_ms, float tilt_fl, float tilt_fr, float tilt_rl, float tilt_rr)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint32_t(buf, 0, time_boot_ms);
+    _mav_put_float(buf, 4, tilt_fl);
+    _mav_put_float(buf, 8, tilt_fr);
+    _mav_put_float(buf, 12, tilt_rl);
+    _mav_put_float(buf, 16, tilt_rr);
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TILT_ANGLE, buf, MAVLINK_MSG_ID_TILT_ANGLE_MIN_LEN, MAVLINK_MSG_ID_TILT_ANGLE_LEN, MAVLINK_MSG_ID_TILT_ANGLE_CRC);
+#else
+    mavlink_tilt_angle_t *packet = (mavlink_tilt_angle_t *)msgbuf;
+    packet->time_boot_ms = time_boot_ms;
+    packet->tilt_fl = tilt_fl;
+    packet->tilt_fr = tilt_fr;
+    packet->tilt_rl = tilt_rl;
+    packet->tilt_rr = tilt_rr;
+
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_TILT_ANGLE, (const char *)packet, MAVLINK_MSG_ID_TILT_ANGLE_MIN_LEN, MAVLINK_MSG_ID_TILT_ANGLE_LEN, MAVLINK_MSG_ID_TILT_ANGLE_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE TILT_ANGLE UNPACKING
+
+
+/**
+ * @brief Get field time_boot_ms from tilt_angle message
+ *
+ * @return [ms] Timestamp (time since system boot).
+ */
+static inline uint32_t mavlink_msg_tilt_angle_get_time_boot_ms(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint32_t(msg,  0);
+}
+
+/**
+ * @brief Get field tilt_fl from tilt_angle message
+ *
+ * @return [deg] Front left tilt angle
+ */
+static inline float mavlink_msg_tilt_angle_get_tilt_fl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  4);
+}
+
+/**
+ * @brief Get field tilt_fr from tilt_angle message
+ *
+ * @return [deg] Front right tilt angle
+ */
+static inline float mavlink_msg_tilt_angle_get_tilt_fr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  8);
+}
+
+/**
+ * @brief Get field tilt_rl from tilt_angle message
+ *
+ * @return [deg] Right left tilt angle
+ */
+static inline float mavlink_msg_tilt_angle_get_tilt_rl(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  12);
+}
+
+/**
+ * @brief Get field tilt_rr from tilt_angle message
+ *
+ * @return [deg] Right right tilt angle
+ */
+static inline float mavlink_msg_tilt_angle_get_tilt_rr(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_float(msg,  16);
+}
+
+/**
+ * @brief Decode a tilt_angle message into a struct
+ *
+ * @param msg The message to decode
+ * @param tilt_angle C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_tilt_angle_decode(const mavlink_message_t* msg, mavlink_tilt_angle_t* tilt_angle)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    tilt_angle->time_boot_ms = mavlink_msg_tilt_angle_get_time_boot_ms(msg);
+    tilt_angle->tilt_fl = mavlink_msg_tilt_angle_get_tilt_fl(msg);
+    tilt_angle->tilt_fr = mavlink_msg_tilt_angle_get_tilt_fr(msg);
+    tilt_angle->tilt_rl = mavlink_msg_tilt_angle_get_tilt_rl(msg);
+    tilt_angle->tilt_rr = mavlink_msg_tilt_angle_get_tilt_rr(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_TILT_ANGLE_LEN? msg->len : MAVLINK_MSG_ID_TILT_ANGLE_LEN;
+        memset(tilt_angle, 0, MAVLINK_MSG_ID_TILT_ANGLE_LEN);
+    memcpy(tilt_angle, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_wifi_network_info.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_msg_wifi_network_info.h
@@ -1,0 +1,362 @@
+#pragma once
+// MESSAGE WIFI_NETWORK_INFO PACKING
+
+#define MAVLINK_MSG_ID_WIFI_NETWORK_INFO 298
+
+
+typedef struct __mavlink_wifi_network_info_t {
+ uint16_t data_rate; /*< [MiB/s] WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.*/
+ char ssid[32]; /*<  Name of Wi-Fi network (SSID).*/
+ uint8_t channel_id; /*<  WiFi network operating channel ID. Set to 0 if unknown or unidentified.*/
+ uint8_t signal_quality; /*< [%] WiFi network signal quality.*/
+ uint8_t security; /*<  WiFi network security type.*/
+} mavlink_wifi_network_info_t;
+
+#define MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN 37
+#define MAVLINK_MSG_ID_WIFI_NETWORK_INFO_MIN_LEN 37
+#define MAVLINK_MSG_ID_298_LEN 37
+#define MAVLINK_MSG_ID_298_MIN_LEN 37
+
+#define MAVLINK_MSG_ID_WIFI_NETWORK_INFO_CRC 237
+#define MAVLINK_MSG_ID_298_CRC 237
+
+#define MAVLINK_MSG_WIFI_NETWORK_INFO_FIELD_SSID_LEN 32
+
+#if MAVLINK_COMMAND_24BIT
+#define MAVLINK_MESSAGE_INFO_WIFI_NETWORK_INFO { \
+    298, \
+    "WIFI_NETWORK_INFO", \
+    5, \
+    {  { "ssid", NULL, MAVLINK_TYPE_CHAR, 32, 2, offsetof(mavlink_wifi_network_info_t, ssid) }, \
+         { "channel_id", NULL, MAVLINK_TYPE_UINT8_T, 0, 34, offsetof(mavlink_wifi_network_info_t, channel_id) }, \
+         { "signal_quality", NULL, MAVLINK_TYPE_UINT8_T, 0, 35, offsetof(mavlink_wifi_network_info_t, signal_quality) }, \
+         { "data_rate", NULL, MAVLINK_TYPE_UINT16_T, 0, 0, offsetof(mavlink_wifi_network_info_t, data_rate) }, \
+         { "security", NULL, MAVLINK_TYPE_UINT8_T, 0, 36, offsetof(mavlink_wifi_network_info_t, security) }, \
+         } \
+}
+#else
+#define MAVLINK_MESSAGE_INFO_WIFI_NETWORK_INFO { \
+    "WIFI_NETWORK_INFO", \
+    5, \
+    {  { "ssid", NULL, MAVLINK_TYPE_CHAR, 32, 2, offsetof(mavlink_wifi_network_info_t, ssid) }, \
+         { "channel_id", NULL, MAVLINK_TYPE_UINT8_T, 0, 34, offsetof(mavlink_wifi_network_info_t, channel_id) }, \
+         { "signal_quality", NULL, MAVLINK_TYPE_UINT8_T, 0, 35, offsetof(mavlink_wifi_network_info_t, signal_quality) }, \
+         { "data_rate", NULL, MAVLINK_TYPE_UINT16_T, 0, 0, offsetof(mavlink_wifi_network_info_t, data_rate) }, \
+         { "security", NULL, MAVLINK_TYPE_UINT8_T, 0, 36, offsetof(mavlink_wifi_network_info_t, security) }, \
+         } \
+}
+#endif
+
+/**
+ * @brief Pack a wifi_network_info message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param ssid  Name of Wi-Fi network (SSID).
+ * @param channel_id  WiFi network operating channel ID. Set to 0 if unknown or unidentified.
+ * @param signal_quality [%] WiFi network signal quality.
+ * @param data_rate [MiB/s] WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.
+ * @param security  WiFi network security type.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_wifi_network_info_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
+                               const char *ssid, uint8_t channel_id, uint8_t signal_quality, uint16_t data_rate, uint8_t security)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN];
+    _mav_put_uint16_t(buf, 0, data_rate);
+    _mav_put_uint8_t(buf, 34, channel_id);
+    _mav_put_uint8_t(buf, 35, signal_quality);
+    _mav_put_uint8_t(buf, 36, security);
+    _mav_put_char_array(buf, 2, ssid, 32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN);
+#else
+    mavlink_wifi_network_info_t packet;
+    packet.data_rate = data_rate;
+    packet.channel_id = channel_id;
+    packet.signal_quality = signal_quality;
+    packet.security = security;
+    mav_array_memcpy(packet.ssid, ssid, sizeof(char)*32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_WIFI_NETWORK_INFO;
+    return mavlink_finalize_message(msg, system_id, component_id, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_MIN_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_CRC);
+}
+
+/**
+ * @brief Pack a wifi_network_info message
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ *
+ * @param ssid  Name of Wi-Fi network (SSID).
+ * @param channel_id  WiFi network operating channel ID. Set to 0 if unknown or unidentified.
+ * @param signal_quality [%] WiFi network signal quality.
+ * @param data_rate [MiB/s] WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.
+ * @param security  WiFi network security type.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_wifi_network_info_pack_status(uint8_t system_id, uint8_t component_id, mavlink_status_t *_status, mavlink_message_t* msg,
+                               const char *ssid, uint8_t channel_id, uint8_t signal_quality, uint16_t data_rate, uint8_t security)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN];
+    _mav_put_uint16_t(buf, 0, data_rate);
+    _mav_put_uint8_t(buf, 34, channel_id);
+    _mav_put_uint8_t(buf, 35, signal_quality);
+    _mav_put_uint8_t(buf, 36, security);
+    _mav_put_char_array(buf, 2, ssid, 32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN);
+#else
+    mavlink_wifi_network_info_t packet;
+    packet.data_rate = data_rate;
+    packet.channel_id = channel_id;
+    packet.signal_quality = signal_quality;
+    packet.security = security;
+    mav_array_memcpy(packet.ssid, ssid, sizeof(char)*32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_WIFI_NETWORK_INFO;
+#if MAVLINK_CRC_EXTRA
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_MIN_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_CRC);
+#else
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, _status, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_MIN_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN);
+#endif
+}
+
+/**
+ * @brief Pack a wifi_network_info message on a channel
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param ssid  Name of Wi-Fi network (SSID).
+ * @param channel_id  WiFi network operating channel ID. Set to 0 if unknown or unidentified.
+ * @param signal_quality [%] WiFi network signal quality.
+ * @param data_rate [MiB/s] WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.
+ * @param security  WiFi network security type.
+ * @return length of the message in bytes (excluding serial stream start sign)
+ */
+static inline uint16_t mavlink_msg_wifi_network_info_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
+                               mavlink_message_t* msg,
+                                   const char *ssid,uint8_t channel_id,uint8_t signal_quality,uint16_t data_rate,uint8_t security)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN];
+    _mav_put_uint16_t(buf, 0, data_rate);
+    _mav_put_uint8_t(buf, 34, channel_id);
+    _mav_put_uint8_t(buf, 35, signal_quality);
+    _mav_put_uint8_t(buf, 36, security);
+    _mav_put_char_array(buf, 2, ssid, 32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN);
+#else
+    mavlink_wifi_network_info_t packet;
+    packet.data_rate = data_rate;
+    packet.channel_id = channel_id;
+    packet.signal_quality = signal_quality;
+    packet.security = security;
+    mav_array_memcpy(packet.ssid, ssid, sizeof(char)*32);
+        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN);
+#endif
+
+    msg->msgid = MAVLINK_MSG_ID_WIFI_NETWORK_INFO;
+    return mavlink_finalize_message_chan(msg, system_id, component_id, chan, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_MIN_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_CRC);
+}
+
+/**
+ * @brief Encode a wifi_network_info struct
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param msg The MAVLink message to compress the data into
+ * @param wifi_network_info C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_wifi_network_info_encode(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg, const mavlink_wifi_network_info_t* wifi_network_info)
+{
+    return mavlink_msg_wifi_network_info_pack(system_id, component_id, msg, wifi_network_info->ssid, wifi_network_info->channel_id, wifi_network_info->signal_quality, wifi_network_info->data_rate, wifi_network_info->security);
+}
+
+/**
+ * @brief Encode a wifi_network_info struct on a channel
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param chan The MAVLink channel this message will be sent over
+ * @param msg The MAVLink message to compress the data into
+ * @param wifi_network_info C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_wifi_network_info_encode_chan(uint8_t system_id, uint8_t component_id, uint8_t chan, mavlink_message_t* msg, const mavlink_wifi_network_info_t* wifi_network_info)
+{
+    return mavlink_msg_wifi_network_info_pack_chan(system_id, component_id, chan, msg, wifi_network_info->ssid, wifi_network_info->channel_id, wifi_network_info->signal_quality, wifi_network_info->data_rate, wifi_network_info->security);
+}
+
+/**
+ * @brief Encode a wifi_network_info struct with provided status structure
+ *
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ * @param status MAVLink status structure
+ * @param msg The MAVLink message to compress the data into
+ * @param wifi_network_info C-struct to read the message contents from
+ */
+static inline uint16_t mavlink_msg_wifi_network_info_encode_status(uint8_t system_id, uint8_t component_id, mavlink_status_t* _status, mavlink_message_t* msg, const mavlink_wifi_network_info_t* wifi_network_info)
+{
+    return mavlink_msg_wifi_network_info_pack_status(system_id, component_id, _status, msg,  wifi_network_info->ssid, wifi_network_info->channel_id, wifi_network_info->signal_quality, wifi_network_info->data_rate, wifi_network_info->security);
+}
+
+/**
+ * @brief Send a wifi_network_info message
+ * @param chan MAVLink channel to send the message
+ *
+ * @param ssid  Name of Wi-Fi network (SSID).
+ * @param channel_id  WiFi network operating channel ID. Set to 0 if unknown or unidentified.
+ * @param signal_quality [%] WiFi network signal quality.
+ * @param data_rate [MiB/s] WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.
+ * @param security  WiFi network security type.
+ */
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+static inline void mavlink_msg_wifi_network_info_send(mavlink_channel_t chan, const char *ssid, uint8_t channel_id, uint8_t signal_quality, uint16_t data_rate, uint8_t security)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char buf[MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN];
+    _mav_put_uint16_t(buf, 0, data_rate);
+    _mav_put_uint8_t(buf, 34, channel_id);
+    _mav_put_uint8_t(buf, 35, signal_quality);
+    _mav_put_uint8_t(buf, 36, security);
+    _mav_put_char_array(buf, 2, ssid, 32);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_WIFI_NETWORK_INFO, buf, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_MIN_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_CRC);
+#else
+    mavlink_wifi_network_info_t packet;
+    packet.data_rate = data_rate;
+    packet.channel_id = channel_id;
+    packet.signal_quality = signal_quality;
+    packet.security = security;
+    mav_array_memcpy(packet.ssid, ssid, sizeof(char)*32);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_WIFI_NETWORK_INFO, (const char *)&packet, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_MIN_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_CRC);
+#endif
+}
+
+/**
+ * @brief Send a wifi_network_info message
+ * @param chan MAVLink channel to send the message
+ * @param struct The MAVLink struct to serialize
+ */
+static inline void mavlink_msg_wifi_network_info_send_struct(mavlink_channel_t chan, const mavlink_wifi_network_info_t* wifi_network_info)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    mavlink_msg_wifi_network_info_send(chan, wifi_network_info->ssid, wifi_network_info->channel_id, wifi_network_info->signal_quality, wifi_network_info->data_rate, wifi_network_info->security);
+#else
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_WIFI_NETWORK_INFO, (const char *)wifi_network_info, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_MIN_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_CRC);
+#endif
+}
+
+#if MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN <= MAVLINK_MAX_PAYLOAD_LEN
+/*
+  This variant of _send() can be used to save stack space by re-using
+  memory from the receive buffer.  The caller provides a
+  mavlink_message_t which is the size of a full mavlink message. This
+  is usually the receive buffer for the channel, and allows a reply to an
+  incoming message with minimum stack space usage.
+ */
+static inline void mavlink_msg_wifi_network_info_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan,  const char *ssid, uint8_t channel_id, uint8_t signal_quality, uint16_t data_rate, uint8_t security)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char *buf = (char *)msgbuf;
+    _mav_put_uint16_t(buf, 0, data_rate);
+    _mav_put_uint8_t(buf, 34, channel_id);
+    _mav_put_uint8_t(buf, 35, signal_quality);
+    _mav_put_uint8_t(buf, 36, security);
+    _mav_put_char_array(buf, 2, ssid, 32);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_WIFI_NETWORK_INFO, buf, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_MIN_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_CRC);
+#else
+    mavlink_wifi_network_info_t *packet = (mavlink_wifi_network_info_t *)msgbuf;
+    packet->data_rate = data_rate;
+    packet->channel_id = channel_id;
+    packet->signal_quality = signal_quality;
+    packet->security = security;
+    mav_array_memcpy(packet->ssid, ssid, sizeof(char)*32);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_WIFI_NETWORK_INFO, (const char *)packet, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_MIN_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_CRC);
+#endif
+}
+#endif
+
+#endif
+
+// MESSAGE WIFI_NETWORK_INFO UNPACKING
+
+
+/**
+ * @brief Get field ssid from wifi_network_info message
+ *
+ * @return  Name of Wi-Fi network (SSID).
+ */
+static inline uint16_t mavlink_msg_wifi_network_info_get_ssid(const mavlink_message_t* msg, char *ssid)
+{
+    return _MAV_RETURN_char_array(msg, ssid, 32,  2);
+}
+
+/**
+ * @brief Get field channel_id from wifi_network_info message
+ *
+ * @return  WiFi network operating channel ID. Set to 0 if unknown or unidentified.
+ */
+static inline uint8_t mavlink_msg_wifi_network_info_get_channel_id(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  34);
+}
+
+/**
+ * @brief Get field signal_quality from wifi_network_info message
+ *
+ * @return [%] WiFi network signal quality.
+ */
+static inline uint8_t mavlink_msg_wifi_network_info_get_signal_quality(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  35);
+}
+
+/**
+ * @brief Get field data_rate from wifi_network_info message
+ *
+ * @return [MiB/s] WiFi network data rate. Set to UINT16_MAX if data_rate information is not supplied.
+ */
+static inline uint16_t mavlink_msg_wifi_network_info_get_data_rate(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint16_t(msg,  0);
+}
+
+/**
+ * @brief Get field security from wifi_network_info message
+ *
+ * @return  WiFi network security type.
+ */
+static inline uint8_t mavlink_msg_wifi_network_info_get_security(const mavlink_message_t* msg)
+{
+    return _MAV_RETURN_uint8_t(msg,  36);
+}
+
+/**
+ * @brief Decode a wifi_network_info message into a struct
+ *
+ * @param msg The message to decode
+ * @param wifi_network_info C-struct to decode the message contents into
+ */
+static inline void mavlink_msg_wifi_network_info_decode(const mavlink_message_t* msg, mavlink_wifi_network_info_t* wifi_network_info)
+{
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    wifi_network_info->data_rate = mavlink_msg_wifi_network_info_get_data_rate(msg);
+    mavlink_msg_wifi_network_info_get_ssid(msg, wifi_network_info->ssid);
+    wifi_network_info->channel_id = mavlink_msg_wifi_network_info_get_channel_id(msg);
+    wifi_network_info->signal_quality = mavlink_msg_wifi_network_info_get_signal_quality(msg);
+    wifi_network_info->security = mavlink_msg_wifi_network_info_get_security(msg);
+#else
+        uint8_t len = msg->len < MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN? msg->len : MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN;
+        memset(wifi_network_info, 0, MAVLINK_MSG_ID_WIFI_NETWORK_INFO_LEN);
+    memcpy(wifi_network_info, _MAV_PAYLOAD(msg), len);
+#endif
+}

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_sha256.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_sha256.h
@@ -1,0 +1,235 @@
+#pragma once
+
+/*
+  sha-256 implementation for MAVLink based on Heimdal sources, with
+  modifications to suit mavlink headers
+ */
+/*
+ * Copyright (c) 1995 - 2001 Kungliga Tekniska Högskolan
+ * (Royal Institute of Technology, Stockholm, Sweden).
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+  allow implementation to provide their own sha256 with the same API
+*/
+#ifndef HAVE_MAVLINK_SHA256
+
+#ifdef MAVLINK_USE_CXX_NAMESPACE
+namespace mavlink {
+#endif
+
+#ifndef MAVLINK_HELPER
+#define MAVLINK_HELPER
+#endif
+
+typedef struct {
+  uint32_t sz[2];
+  uint32_t counter[8];
+  union {
+      unsigned char save_bytes[64];
+      uint32_t save_u32[16];
+  } u;
+} mavlink_sha256_ctx;
+
+#define Ch(x,y,z) (((x) & (y)) ^ ((~(x)) & (z)))
+#define Maj(x,y,z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+
+#define ROTR(x,n)   (((x)>>(n)) | ((x) << (32 - (n))))
+
+#define Sigma0(x)	(ROTR(x,2)  ^ ROTR(x,13) ^ ROTR(x,22))
+#define Sigma1(x)	(ROTR(x,6)  ^ ROTR(x,11) ^ ROTR(x,25))
+#define sigma0(x)	(ROTR(x,7)  ^ ROTR(x,18) ^ ((x)>>3))
+#define sigma1(x)	(ROTR(x,17) ^ ROTR(x,19) ^ ((x)>>10))
+
+static const uint32_t mavlink_sha256_constant_256[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+    0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+    0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+    0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+    0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+    0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+MAVLINK_HELPER void mavlink_sha256_init(mavlink_sha256_ctx *m)
+{
+    m->sz[0] = 0;
+    m->sz[1] = 0;
+    m->counter[0] = 0x6a09e667;
+    m->counter[1] = 0xbb67ae85;
+    m->counter[2] = 0x3c6ef372;
+    m->counter[3] = 0xa54ff53a;
+    m->counter[4] = 0x510e527f;
+    m->counter[5] = 0x9b05688c;
+    m->counter[6] = 0x1f83d9ab;
+    m->counter[7] = 0x5be0cd19;
+}
+
+static inline void mavlink_sha256_calc(mavlink_sha256_ctx *m, uint32_t *in)
+{
+    uint32_t AA, BB, CC, DD, EE, FF, GG, HH;
+    uint32_t data[64];
+    int i;
+
+    AA = m->counter[0];
+    BB = m->counter[1];
+    CC = m->counter[2];
+    DD = m->counter[3];
+    EE = m->counter[4];
+    FF = m->counter[5];
+    GG = m->counter[6];
+    HH = m->counter[7];
+
+    for (i = 0; i < 16; ++i)
+	data[i] = in[i];
+    for (i = 16; i < 64; ++i)
+	data[i] = sigma1(data[i-2]) + data[i-7] + 
+	    sigma0(data[i-15]) + data[i - 16];
+
+    for (i = 0; i < 64; i++) {
+	uint32_t T1, T2;
+
+	T1 = HH + Sigma1(EE) + Ch(EE, FF, GG) + mavlink_sha256_constant_256[i] + data[i];
+	T2 = Sigma0(AA) + Maj(AA,BB,CC);
+			     
+	HH = GG;
+	GG = FF;
+	FF = EE;
+	EE = DD + T1;
+	DD = CC;
+	CC = BB;
+	BB = AA;
+	AA = T1 + T2;
+    }
+
+    m->counter[0] += AA;
+    m->counter[1] += BB;
+    m->counter[2] += CC;
+    m->counter[3] += DD;
+    m->counter[4] += EE;
+    m->counter[5] += FF;
+    m->counter[6] += GG;
+    m->counter[7] += HH;
+}
+
+MAVLINK_HELPER void mavlink_sha256_update(mavlink_sha256_ctx *m, const void *v, uint32_t len)
+{
+    const unsigned char *p = (const unsigned char *)v;
+    uint32_t old_sz = m->sz[0];
+    uint32_t offset;
+
+    m->sz[0] += len * 8;
+    if (m->sz[0] < old_sz)
+	++m->sz[1];
+    offset = (old_sz / 8) % 64;
+    while(len > 0){
+	uint32_t l = 64 - offset;
+        if (len < l) {
+            l = len;
+        }
+	memcpy(m->u.save_bytes + offset, p, l);
+	offset += l;
+	p += l;
+	len -= l;
+	if(offset == 64){
+	    int i;
+	    uint32_t current[16];
+	    const uint32_t *u = m->u.save_u32;
+	    for (i = 0; i < 16; i++){
+                const uint8_t *p1 = (const uint8_t *)&u[i];
+                uint8_t *p2 = (uint8_t *)&current[i];
+                p2[0] = p1[3];
+                p2[1] = p1[2];
+                p2[2] = p1[1];
+                p2[3] = p1[0];
+	    }
+	    mavlink_sha256_calc(m, current);
+	    offset = 0;
+	}
+    }
+}
+
+/*
+  get first 48 bits of final sha256 hash
+ */
+MAVLINK_HELPER void mavlink_sha256_final_48(mavlink_sha256_ctx *m, uint8_t result[6])
+{
+    unsigned char zeros[72];
+    unsigned offset = (m->sz[0] / 8) % 64;
+    unsigned int dstart = (120 - offset - 1) % 64 + 1;
+    uint8_t *p = (uint8_t *)&m->counter[0];
+    
+    *zeros = 0x80;
+    memset (zeros + 1, 0, sizeof(zeros) - 1);
+    zeros[dstart+7] = (m->sz[0] >> 0) & 0xff;
+    zeros[dstart+6] = (m->sz[0] >> 8) & 0xff;
+    zeros[dstart+5] = (m->sz[0] >> 16) & 0xff;
+    zeros[dstart+4] = (m->sz[0] >> 24) & 0xff;
+    zeros[dstart+3] = (m->sz[1] >> 0) & 0xff;
+    zeros[dstart+2] = (m->sz[1] >> 8) & 0xff;
+    zeros[dstart+1] = (m->sz[1] >> 16) & 0xff;
+    zeros[dstart+0] = (m->sz[1] >> 24) & 0xff;
+
+    mavlink_sha256_update(m, zeros, dstart + 8);
+
+    // this ordering makes the result consistent with taking the first
+    // 6 bytes of more conventional sha256 functions. It assumes
+    // little-endian ordering of m->counter
+    result[0] = p[3];
+    result[1] = p[2];
+    result[2] = p[1];
+    result[3] = p[0];
+    result[4] = p[7];
+    result[5] = p[6];
+}
+
+// prevent conflicts with users of the header
+#undef Ch
+#undef ROTR
+#undef Sigma0
+#undef Sigma1
+#undef sigma0
+#undef sigma1
+
+#ifdef MAVLINK_USE_CXX_NAMESPACE
+} // namespace mavlink
+#endif
+
+#endif // HAVE_MAVLINK_SHA256

--- a/libs/mavlink/include/mavlink/v2.0/development/mavlink_types.h
+++ b/libs/mavlink/include/mavlink/v2.0/development/mavlink_types.h
@@ -1,0 +1,312 @@
+#pragma once
+
+// Visual Studio versions before 2010 don't have stdint.h, so we just error out.
+#if (defined _MSC_VER) && (_MSC_VER < 1600)
+#error "The C-MAVLink implementation requires Visual Studio 2010 or greater"
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef MAVLINK_USE_CXX_NAMESPACE
+namespace mavlink {
+#endif
+
+// Macro to define packed structures
+#ifdef __GNUC__
+  #define MAVPACKED( __Declaration__ ) __Declaration__ __attribute__((packed))
+#else
+  #define MAVPACKED( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
+#endif
+
+#ifndef MAVLINK_MAX_PAYLOAD_LEN
+// it is possible to override this, but be careful!
+#define MAVLINK_MAX_PAYLOAD_LEN 255 ///< Maximum payload length
+#endif
+
+#define MAVLINK_CORE_HEADER_LEN 9 ///< Length of core header (of the comm. layer)
+#define MAVLINK_CORE_HEADER_MAVLINK1_LEN 5 ///< Length of MAVLink1 core header (of the comm. layer)
+#define MAVLINK_NUM_HEADER_BYTES (MAVLINK_CORE_HEADER_LEN + 1) ///< Length of all header bytes, including core and stx
+#define MAVLINK_NUM_CHECKSUM_BYTES 2
+#define MAVLINK_NUM_NON_PAYLOAD_BYTES (MAVLINK_NUM_HEADER_BYTES + MAVLINK_NUM_CHECKSUM_BYTES)
+
+#define MAVLINK_SIGNATURE_BLOCK_LEN 13
+
+#define MAVLINK_MAX_PACKET_LEN (MAVLINK_MAX_PAYLOAD_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES + MAVLINK_SIGNATURE_BLOCK_LEN) ///< Maximum packet length
+
+/**
+ * Old-style 4 byte param union
+ *
+ * This struct is the data format to be used when sending
+ * parameters. The parameter should be copied to the native
+ * type (without type conversion)
+ * and re-instanted on the receiving side using the
+ * native type as well.
+ */
+MAVPACKED(
+typedef struct param_union {
+	union {
+		float param_float;
+		int32_t param_int32;
+		uint32_t param_uint32;
+		int16_t param_int16;
+		uint16_t param_uint16;
+		int8_t param_int8;
+		uint8_t param_uint8;
+		uint8_t bytes[4];
+	};
+	uint8_t type;
+}) mavlink_param_union_t;
+
+
+/**
+ * New-style 8 byte param union
+ * mavlink_param_union_double_t will be 8 bytes long, and treated as needing 8 byte alignment for the purposes of MAVLink 1.0 field ordering.
+ * The mavlink_param_union_double_t will be treated as a little-endian structure.
+ *
+ * If is_double is 1 then the type is a double, and the remaining 63 bits are the double, with the lowest bit of the mantissa zero.
+ * The intention is that by replacing the is_double bit with 0 the type can be directly used as a double (as the is_double bit corresponds to the
+ * lowest mantissa bit of a double). If is_double is 0 then mavlink_type gives the type in the union.
+ * The mavlink_types.h header will also need to have shifts/masks to define the bit boundaries in the above,
+ * as bitfield ordering isn't consistent between platforms. The above is intended to be for gcc on x86,
+ * which should be the same as gcc on little-endian arm. When using shifts/masks the value will be treated as a 64 bit unsigned number,
+ * and the bits pulled out using the shifts/masks.
+*/
+MAVPACKED(
+typedef struct param_union_extended {
+    union {
+    struct {
+        uint8_t is_double:1;
+        uint8_t mavlink_type:7;
+        union {
+            char c;
+            uint8_t uint8;
+            int8_t int8;
+            uint16_t uint16;
+            int16_t int16;
+            uint32_t uint32;
+            int32_t int32;
+            float f;
+            uint8_t align[7];
+        };
+    };
+    uint8_t data[8];
+    };
+}) mavlink_param_union_double_t;
+
+/**
+ * This structure is required to make the mavlink_send_xxx convenience functions
+ * work, as it tells the library what the current system and component ID are.
+ */
+MAVPACKED(
+typedef struct __mavlink_system {
+    uint8_t sysid;   ///< Used by the MAVLink message_xx_send() convenience function
+    uint8_t compid;  ///< Used by the MAVLink message_xx_send() convenience function
+}) mavlink_system_t;
+
+MAVPACKED(
+typedef struct __mavlink_message {
+	uint16_t checksum;      ///< sent at end of packet
+	uint8_t magic;          ///< protocol magic marker
+	uint8_t len;            ///< Length of payload
+	uint8_t incompat_flags; ///< flags that must be understood
+	uint8_t compat_flags;   ///< flags that can be ignored if not understood
+	uint8_t seq;            ///< Sequence of packet
+	uint8_t sysid;          ///< ID of message sender system/aircraft
+	uint8_t compid;         ///< ID of the message sender component
+	uint32_t msgid:24;      ///< ID of message in payload
+	uint64_t payload64[(MAVLINK_MAX_PAYLOAD_LEN+MAVLINK_NUM_CHECKSUM_BYTES+7)/8];
+	uint8_t ck[2];          ///< incoming checksum bytes
+	uint8_t signature[MAVLINK_SIGNATURE_BLOCK_LEN];
+}) mavlink_message_t;
+
+typedef enum {
+	MAVLINK_TYPE_CHAR     = 0,
+	MAVLINK_TYPE_UINT8_T  = 1,
+	MAVLINK_TYPE_INT8_T   = 2,
+	MAVLINK_TYPE_UINT16_T = 3,
+	MAVLINK_TYPE_INT16_T  = 4,
+	MAVLINK_TYPE_UINT32_T = 5,
+	MAVLINK_TYPE_INT32_T  = 6,
+	MAVLINK_TYPE_UINT64_T = 7,
+	MAVLINK_TYPE_INT64_T  = 8,
+	MAVLINK_TYPE_FLOAT    = 9,
+	MAVLINK_TYPE_DOUBLE   = 10
+} mavlink_message_type_t;
+
+#define MAVLINK_MAX_FIELDS 64
+
+typedef struct __mavlink_field_info {
+	const char *name;                 // name of this field
+        const char *print_format;         // printing format hint, or NULL
+        mavlink_message_type_t type;      // type of this field
+        unsigned int array_length;        // if non-zero, field is an array
+        unsigned int wire_offset;         // offset of each field in the payload
+        unsigned int structure_offset;    // offset in a C structure
+} mavlink_field_info_t;
+
+// note that in this structure the order of fields is the order
+// in the XML file, not necessary the wire order
+typedef struct __mavlink_message_info {
+	uint32_t msgid;                                        // message ID
+	const char *name;                                      // name of the message
+	unsigned num_fields;                                   // how many fields in this message
+	mavlink_field_info_t fields[MAVLINK_MAX_FIELDS];       // field information
+} mavlink_message_info_t;
+
+#define _MAV_PAYLOAD(msg) ((const char *)(&((msg)->payload64[0])))
+#define _MAV_PAYLOAD_NON_CONST(msg) ((char *)(&((msg)->payload64[0])))
+
+// checksum is immediately after the payload bytes
+#define mavlink_ck_a(msg) *((msg)->len + (uint8_t *)_MAV_PAYLOAD_NON_CONST(msg))
+#define mavlink_ck_b(msg) *(((msg)->len+(uint16_t)1) + (uint8_t *)_MAV_PAYLOAD_NON_CONST(msg))
+
+#ifndef HAVE_MAVLINK_CHANNEL_T
+typedef enum {
+    MAVLINK_COMM_0,
+    MAVLINK_COMM_1,
+    MAVLINK_COMM_2,
+    MAVLINK_COMM_3
+} mavlink_channel_t;
+#endif
+
+/*
+ * applications can set MAVLINK_COMM_NUM_BUFFERS to the maximum number
+ * of buffers they will use. If more are used, then the result will be
+ * a stack overrun
+ */
+#ifndef MAVLINK_COMM_NUM_BUFFERS
+#if (defined linux) | (defined __linux) | (defined  __MACH__) | (defined _WIN32)
+# define MAVLINK_COMM_NUM_BUFFERS 16
+#else
+# define MAVLINK_COMM_NUM_BUFFERS 4
+#endif
+#endif
+
+typedef enum {
+    MAVLINK_PARSE_STATE_UNINIT=0,
+    MAVLINK_PARSE_STATE_IDLE,
+    MAVLINK_PARSE_STATE_GOT_STX,
+    MAVLINK_PARSE_STATE_GOT_LENGTH,
+    MAVLINK_PARSE_STATE_GOT_INCOMPAT_FLAGS,
+    MAVLINK_PARSE_STATE_GOT_COMPAT_FLAGS,
+    MAVLINK_PARSE_STATE_GOT_SEQ,
+    MAVLINK_PARSE_STATE_GOT_SYSID,
+    MAVLINK_PARSE_STATE_GOT_COMPID,
+    MAVLINK_PARSE_STATE_GOT_MSGID1,
+    MAVLINK_PARSE_STATE_GOT_MSGID2,
+    MAVLINK_PARSE_STATE_GOT_MSGID3,
+    MAVLINK_PARSE_STATE_GOT_PAYLOAD,
+    MAVLINK_PARSE_STATE_GOT_CRC1,
+    MAVLINK_PARSE_STATE_GOT_BAD_CRC1,
+    MAVLINK_PARSE_STATE_SIGNATURE_WAIT
+} mavlink_parse_state_t; ///< The state machine for the comm parser
+
+typedef enum {
+    MAVLINK_FRAMING_INCOMPLETE=0,
+    MAVLINK_FRAMING_OK=1,
+    MAVLINK_FRAMING_BAD_CRC=2,
+    MAVLINK_FRAMING_BAD_SIGNATURE=3
+} mavlink_framing_t;
+
+#define MAVLINK_STATUS_FLAG_IN_MAVLINK1  1 // last incoming packet was MAVLink1
+#define MAVLINK_STATUS_FLAG_OUT_MAVLINK1 2 // generate MAVLink1 by default
+#define MAVLINK_STATUS_FLAG_IN_SIGNED    4 // last incoming packet was signed and validated
+#define MAVLINK_STATUS_FLAG_IN_BADSIG    8 // last incoming packet had a bad signature
+
+#define MAVLINK_STX_MAVLINK1 0xFE          // marker for old protocol
+
+typedef struct __mavlink_status {
+    uint8_t msg_received;               ///< Number of received messages
+    uint8_t buffer_overrun;             ///< Number of buffer overruns
+    uint8_t parse_error;                ///< Number of parse errors
+    mavlink_parse_state_t parse_state;  ///< Parsing state machine
+    uint8_t packet_idx;                 ///< Index in current packet
+    uint8_t current_rx_seq;             ///< Sequence number of last packet received
+    uint8_t current_tx_seq;             ///< Sequence number of last packet sent
+    uint16_t packet_rx_success_count;   ///< Received packets
+    uint16_t packet_rx_drop_count;      ///< Number of packet drops
+    uint8_t flags;                      ///< MAVLINK_STATUS_FLAG_*
+    uint8_t signature_wait;             ///< number of signature bytes left to receive
+    struct __mavlink_signing *signing;  ///< optional signing state
+    struct __mavlink_signing_streams *signing_streams; ///< global record of stream timestamps
+} mavlink_status_t;
+
+/*
+  a callback function to allow for accepting unsigned packets
+ */
+typedef bool (*mavlink_accept_unsigned_t)(const mavlink_status_t *status, uint32_t msgid);
+
+/*
+  flags controlling signing
+ */
+#define MAVLINK_SIGNING_FLAG_SIGN_OUTGOING 1    ///< Enable outgoing signing
+
+typedef enum {
+    MAVLINK_SIGNING_STATUS_NONE=0,
+    MAVLINK_SIGNING_STATUS_OK=1,
+    MAVLINK_SIGNING_STATUS_BAD_SIGNATURE=2,
+    MAVLINK_SIGNING_STATUS_NO_STREAMS=3,
+    MAVLINK_SIGNING_STATUS_TOO_MANY_STREAMS=4,
+    MAVLINK_SIGNING_STATUS_OLD_TIMESTAMP=5,
+    MAVLINK_SIGNING_STATUS_REPLAY=6,
+} mavlink_signing_status_t;
+    
+/*
+  state of MAVLink signing for this channel
+ */
+typedef struct __mavlink_signing {
+    uint8_t flags;                     ///< MAVLINK_SIGNING_FLAG_*
+    uint8_t link_id;                   ///< Same as MAVLINK_CHANNEL
+    uint64_t timestamp;                ///< Timestamp, in microseconds since UNIX epoch GMT
+    uint8_t secret_key[32];
+    mavlink_accept_unsigned_t accept_unsigned_callback;
+    mavlink_signing_status_t last_status;
+} mavlink_signing_t;
+
+/*
+  timestamp state of each logical signing stream. This needs to be the same structure for all
+  connections in order to be secure
+ */
+#ifndef MAVLINK_MAX_SIGNING_STREAMS
+#define MAVLINK_MAX_SIGNING_STREAMS 16
+#endif
+typedef struct __mavlink_signing_streams {
+    uint16_t num_signing_streams;
+    struct __mavlink_signing_stream {
+        uint8_t link_id;              ///< ID of the link (MAVLINK_CHANNEL)
+        uint8_t sysid;                ///< Remote system ID
+        uint8_t compid;               ///< Remote component ID
+        uint8_t timestamp_bytes[6];   ///< Timestamp, in microseconds since UNIX epoch GMT
+    } stream[MAVLINK_MAX_SIGNING_STREAMS];
+} mavlink_signing_streams_t;
+
+
+#define MAVLINK_BIG_ENDIAN 0
+#define MAVLINK_LITTLE_ENDIAN 1
+
+#define MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM    1
+#define MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT 2
+
+/*
+  entry in table of information about each message type
+ */
+typedef struct __mavlink_msg_entry {
+	uint32_t msgid;
+	uint8_t crc_extra;
+        uint8_t min_msg_len;       // minimum message length
+        uint8_t max_msg_len;       // maximum message length (e.g. including mavlink2 extensions)
+        uint8_t flags;             // MAV_MSG_ENTRY_FLAG_*
+	uint8_t target_system_ofs; // payload offset to target_system, or 0
+	uint8_t target_component_ofs; // payload offset to target_component, or 0
+} mavlink_msg_entry_t;
+
+/*
+  incompat_flags bits
+ */
+#define MAVLINK_IFLAG_SIGNED  0x01
+#define MAVLINK_IFLAG_MASK    0x01 // mask of all understood bits
+
+#ifdef MAVLINK_USE_CXX_NAMESPACE
+} // namespace mavlink
+#endif

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -360,6 +360,8 @@
         <file alias="MockLinkSettings.qml">src/UI/preferences/MockLinkSettings.qml</file>
         
         <file alias="QGroundControl/FlightDisplay/CustomDisplayPanel.qml">src/FlightDisplay/CustomDisplayPanel.qml</file>
+        <file alias="QGroundControl/FlightDisplay/ControlSurfaceHUD.qml">src/FlightDisplay/ControlSurfaceHUD.qml</file>
+        <file alias="QGroundControl/FlightDisplay/EscHBCIHud.qml">src/FlightDisplay/EscHBCIHud.qml</file>        
     </qresource>
     <qresource prefix="/FirstRunPromptDialogs">
         <file alias="UnitsFirstRunPrompt.qml">src/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml</file>
@@ -435,6 +437,10 @@
         
         <file alias="Vehicle/FakeFactGroup.json">src/Vehicle/FactGroups/FakeFactGroup.json</file>
         <file alias="Vehicle/CustomTiltAngleFactGroup.json">src/Vehicle/FactGroups/CustomTiltAngleFactGroup.json</file>
+
+        <file alias="Vehicle/ControlSurfaceCmdFactGroup.json">src/Vehicle/FactGroups/ControlSurfaceCmdFactGroup.json</file>
+        <file alias="Vehicle/EscHBCIFactGroup.json">src/Vehicle/FactGroups/EscHBCIFactGroup.json</file>
+
     </qresource>
     <qresource prefix="/MockLink">
         <file alias="APMArduSubMockLink.params">src/Comms/MockLink/APMArduSubMockLink.params</file>

--- a/src/FlightDisplay/ControlSurfaceHUD.qml
+++ b/src/FlightDisplay/ControlSurfaceHUD.qml
@@ -1,0 +1,37 @@
+import QtQuick
+import QtQuick.Controls
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.FlightDisplay
+import QGroundControl.Vehicle
+
+Rectangle {
+    width: 300
+    height: 200
+    color: "#333333"
+
+    property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+    Column {
+        anchors.centerIn: parent
+        spacing: 10
+
+        Label {
+            text: "Left Aileron: " + (_activeVehicle ? _activeVehicle.controlSurfaceCmd.leftAileron.valueString : "--") + " deg"
+            color: "white"
+        }
+        Label {
+            text: "Right Aileron: " + (_activeVehicle ? _activeVehicle.controlSurfaceCmd.rightAileron.valueString : "--") + " deg"
+            color: "white"
+        }
+        Label {
+            text: "Left Ruddervator: " + (_activeVehicle ? _activeVehicle.controlSurfaceCmd.leftRuddervator.valueString : "--") + " deg"
+            color: "white"
+        }
+        Label {
+            text: "Right Ruddervator: " + (_activeVehicle ? _activeVehicle.controlSurfaceCmd.rightRuddervator.valueString : "--") + " deg"
+            color: "white"
+        }
+    }
+}

--- a/src/FlightDisplay/EscHBCIHUD.qml
+++ b/src/FlightDisplay/EscHBCIHUD.qml
@@ -1,0 +1,60 @@
+import QtQuick
+import QtQuick.Controls
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.FlightDisplay
+import QGroundControl.Vehicle
+
+Rectangle {
+    width: 400
+    height: 700
+    color: "#222222"
+    border.color: "#888888"
+    border.width: 1
+    radius: 8
+
+    property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+    Column {
+        anchors.centerIn: parent
+        spacing: 5
+
+        Label { text: "ESC HBCI Monitor" ; color: "white"; font.bold: true }
+
+        Label { text: "Voltage FL: " + (_activeVehicle ? _activeVehicle.escHBCI.voltageFl.valueString : "--") + " V"; color: "white" }
+        Label { text: "Voltage FR: " + (_activeVehicle ? _activeVehicle.escHBCI.voltageFr.valueString : "--") + " V"; color: "white" }
+        Label { text: "Voltage RL: " + (_activeVehicle ? _activeVehicle.escHBCI.voltageRl.valueString : "--") + " V"; color: "white" }
+        Label { text: "Voltage RR: " + (_activeVehicle ? _activeVehicle.escHBCI.voltageRr.valueString : "--") + " V"; color: "white" }
+
+        Label { text: "Current FL: " + (_activeVehicle ? _activeVehicle.escHBCI.currentFl.valueString : "--") + " A"; color: "white" }
+        Label { text: "Current FR: " + (_activeVehicle ? _activeVehicle.escHBCI.currentFr.valueString : "--") + " A"; color: "white" }
+        Label { text: "Current RL: " + (_activeVehicle ? _activeVehicle.escHBCI.currentRl.valueString : "--") + " A"; color: "white" }
+        Label { text: "Current RR: " + (_activeVehicle ? _activeVehicle.escHBCI.currentRr.valueString : "--") + " A"; color: "white" }
+
+        Label { text: "RPM FL: " + (_activeVehicle ? _activeVehicle.escHBCI.rpmFl.valueString : "--") + " RPM"; color: "white" }
+        Label { text: "RPM FR: " + (_activeVehicle ? _activeVehicle.escHBCI.rpmFr.valueString : "--") + " RPM"; color: "white" }
+        Label { text: "RPM RL: " + (_activeVehicle ? _activeVehicle.escHBCI.rpmRl.valueString : "--") + " RPM"; color: "white" }
+        Label { text: "RPM RR: " + (_activeVehicle ? _activeVehicle.escHBCI.rpmRr.valueString : "--") + " RPM"; color: "white" }
+
+        Label { text: "MotorTemp FL: " + (_activeVehicle ? _activeVehicle.escHBCI.motorTempFl.valueString : "--") + "°C"; color: "white" }
+        Label { text: "MotorTemp FR: " + (_activeVehicle ? _activeVehicle.escHBCI.motorTempFr.valueString : "--") + "°C"; color: "white" }
+        Label { text: "MotorTemp RL: " + (_activeVehicle ? _activeVehicle.escHBCI.motorTempRl.valueString : "--") + "°C"; color: "white" }
+        Label { text: "MotorTemp RR: " + (_activeVehicle ? _activeVehicle.escHBCI.motorTempRr.valueString : "--") + "°C"; color: "white" }
+
+        Label { text: "ESCTemp FL: " + (_activeVehicle ? _activeVehicle.escHBCI.escTempFl.valueString : "--") + "°C"; color: "white" }
+        Label { text: "ESCTemp FR: " + (_activeVehicle ? _activeVehicle.escHBCI.escTempFr.valueString : "--") + "°C"; color: "white" }
+        Label { text: "ESCTemp RL: " + (_activeVehicle ? _activeVehicle.escHBCI.escTempRl.valueString : "--") + "°C"; color: "white" }
+        Label { text: "ESCTemp RR: " + (_activeVehicle ? _activeVehicle.escHBCI.escTempRr.valueString : "--") + "°C"; color: "white" }
+
+        Label { text: "OutputPWM FL: " + (_activeVehicle ? _activeVehicle.escHBCI.outputPwmFl.valueString : "--") + " %"; color: "white" }
+        Label { text: "OutputPWM FR: " + (_activeVehicle ? _activeVehicle.escHBCI.outputPwmFr.valueString : "--") + " %"; color: "white" }
+        Label { text: "OutputPWM RL: " + (_activeVehicle ? _activeVehicle.escHBCI.outputPwmRl.valueString : "--") + " %"; color: "white" }
+        Label { text: "OutputPWM RR: " + (_activeVehicle ? _activeVehicle.escHBCI.outputPwmRr.valueString : "--") + " %"; color: "white" }
+
+        Label { text: "InputPWM FL: " + (_activeVehicle ? _activeVehicle.escHBCI.inputPwmFl.valueString : "--") + " %"; color: "white" }
+        Label { text: "InputPWM FR: " + (_activeVehicle ? _activeVehicle.escHBCI.inputPwmFr.valueString : "--") + " %"; color: "white" }
+        Label { text: "InputPWM RL: " + (_activeVehicle ? _activeVehicle.escHBCI.inputPwmRl.valueString : "--") + " %"; color: "white" }
+        Label { text: "InputPWM RR: " + (_activeVehicle ? _activeVehicle.escHBCI.inputPwmRr.valueString : "--") + " %"; color: "white" }
+    }
+}

--- a/src/QmlControls/InstrumentValueData.cc
+++ b/src/QmlControls/InstrumentValueData.cc
@@ -347,7 +347,6 @@ QStringList InstrumentValueData::factGroupNames(void) const
         name[0] = name[0].toUpper();
     }
     groupNames.prepend(vehicleFactGroupName);
-    qDebug() << "DEBUG: Final factGroupNames (after prepend):" << groupNames; 
     return groupNames;
 }
 

--- a/src/QmlControls/InstrumentValueValue.qml
+++ b/src/QmlControls/InstrumentValueValue.qml
@@ -41,7 +41,16 @@ ColumnLayout {
 
         function valueText() {
             if (instrumentValueData.fact) {
-                return instrumentValueData.fact.enumOrValueString + (instrumentValueData.showUnits ? " " + instrumentValueData.fact.units : "")
+                let fact = instrumentValueData.fact
+                let value = fact.value
+                let units = instrumentValueData.showUnits ? " " + fact.units : ""
+
+                if (typeof fact.decimalPlaces === "number" && typeof value === "number") {
+                    let formattedValue = value.toFixed(fact.decimalPlaces)
+                    return formattedValue + units
+                } else {
+                    return fact.enumOrValueString + units
+                }
             } else {
                 return qsTr("--.--")
             }

--- a/src/QmlControls/QGroundControl/FlightDisplay/qmldir
+++ b/src/QmlControls/QGroundControl/FlightDisplay/qmldir
@@ -51,3 +51,6 @@ TerrainProgress                 1.0 TerrainProgress.qml
 VehicleWarnings                 1.0 VehicleWarnings.qml
 
 CustomDisplayPanel              1.0 CustomDisplayPanel.qml
+
+ControlSurfaceHUD               1.0 ControlSurfaceHUD.qml
+EscHBCIHud                      1.0 EscHBCIHud.qml

--- a/src/Vehicle/FactGroups/CMakeLists.txt
+++ b/src/Vehicle/FactGroups/CMakeLists.txt
@@ -44,6 +44,19 @@ target_sources(${CMAKE_PROJECT_NAME}
 
         CustomTiltAngleFactGroup.cc
         CustomTiltAngleFactGroup.h
+
+        ControlSurfaceCmdFactGroup.h
+        ControlSurfaceCmdFactGroup.cc
+
+        EscHBCIFactGroup.h
+        EscHBCIFactGroup.cc
 )
 
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/libs/mavlink/include
+        ${CMAKE_SOURCE_DIR}/libs/mavlink/include/mavlink/v2.0
+        ${CMAKE_SOURCE_DIR}/libs/mavlink/include/mavlink/v2.0/development
+)

--- a/src/Vehicle/FactGroups/ControlSurfaceCmdFactGroup.cc
+++ b/src/Vehicle/FactGroups/ControlSurfaceCmdFactGroup.cc
@@ -1,0 +1,49 @@
+#define MAVLINK_ENABLED_TILT_CTRL // mavlink custom 메시지 헤더를 찾을 수 있도록
+
+#include "ControlSurfaceCmdFactGroup.h"
+#include "mavlink/v2.0/development/mavlink_msg_control_surface_cmd.h"
+#include <QDebug> // qDebug() 사용
+
+
+
+ControlSurfaceCmdFactGroup::ControlSurfaceCmdFactGroup(QObject* parent)
+    : FactGroup(1000, ":/json/Vehicle/ControlSurfaceCmdFactGroup.json", parent)
+{
+    setObjectName("ControlSurfaceCmdFactGroup");
+
+    // 각 필드 등록 - 반드시 json name과 일치
+    _addFact(&_leftAileronFact, "leftAileron");
+    _addFact(&_rightAileronFact, "rightAileron");
+    _addFact(&_leftRuddervatorFact, "leftRuddervator");
+    _addFact(&_rightRuddervatorFact, "rightRuddervator");
+}
+
+void ControlSurfaceCmdFactGroup::handleMessage(Vehicle *vehicle, const mavlink_message_t &message) {
+    switch (message.msgid) {
+        case MAVLINK_MSG_ID_CONTROL_SURFACE_CMD:
+            qDebug() << "Received MAVLINK_MSG_ID_CONTROL_SURFACE_CMD.";
+            _handleControlSurfaceCmd(message);
+            break;
+        default:
+            break;
+    }
+}
+
+void ControlSurfaceCmdFactGroup::_handleControlSurfaceCmd(const mavlink_message_t &message) {
+    mavlink_control_surface_cmd_t surfCmd{};
+    mavlink_msg_control_surface_cmd_decode(&message, &surfCmd);
+    _updateControlSurfaceCmd(
+        surfCmd.left_aileron,
+        surfCmd.right_aileron,
+        surfCmd.left_ruddervator,
+        surfCmd.right_ruddervator
+    );
+    _setTelemetryAvailable(true); // FactGroup 함수
+}
+
+void ControlSurfaceCmdFactGroup::_updateControlSurfaceCmd(float leftAil, float rightAil, float leftRud, float rightRud) {
+    _leftAileronFact.setRawValue(leftAil);
+    _rightAileronFact.setRawValue(rightAil);
+    _leftRuddervatorFact.setRawValue(leftRud);
+    _rightRuddervatorFact.setRawValue(rightRud);
+}

--- a/src/Vehicle/FactGroups/ControlSurfaceCmdFactGroup.h
+++ b/src/Vehicle/FactGroups/ControlSurfaceCmdFactGroup.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "FactGroup.h"
+
+class ControlSurfaceCmdFactGroup : public FactGroup
+{
+    Q_OBJECT
+    // QML에서 vehicle.controlSurfaceCmd.leftAileron.valueString 식으로 사용
+    Q_PROPERTY(Fact* leftAileron READ leftAileron CONSTANT)
+    Q_PROPERTY(Fact* rightAileron READ rightAileron CONSTANT)
+    Q_PROPERTY(Fact* leftRuddervator READ leftRuddervator CONSTANT)
+    Q_PROPERTY(Fact* rightRuddervator READ rightRuddervator CONSTANT)
+
+public:
+    explicit ControlSurfaceCmdFactGroup(QObject* parent = nullptr);
+
+    // 각 Fact를 반환하는 Getter 함수들
+    Fact* leftAileron() { return &_leftAileronFact; }
+    Fact* rightAileron() { return &_rightAileronFact; }
+    Fact* leftRuddervator() { return &_leftRuddervatorFact; }
+    Fact* rightRuddervator() { return &_rightRuddervatorFact; }
+
+    // MAVLink 메시지 수신시 호출 (오버라이드)
+    void handleMessage(Vehicle* vehicle, const mavlink_message_t& message) override;
+
+protected:
+    void _handleControlSurfaceCmd(const mavlink_message_t& message);
+
+    // 각 변수에 실제 값을 저장
+    Fact _leftAileronFact;
+    Fact _rightAileronFact;
+    Fact _leftRuddervatorFact;
+    Fact _rightRuddervatorFact;
+
+private:
+    void _updateControlSurfaceCmd(float leftAil, float rightAil, float leftRud, float rightRud);
+};

--- a/src/Vehicle/FactGroups/ControlSurfaceCmdFactGroup.json
+++ b/src/Vehicle/FactGroups/ControlSurfaceCmdFactGroup.json
@@ -1,0 +1,30 @@
+{
+    "version":      1, 
+    "fileType":     "FactMetaData",
+    "QGC.MetaData.Facts": [
+        {
+            "name": "leftAileron",
+            "shortDesc": "Left Aileron",
+            "type": "float",
+            "units": "deg"
+        },
+        {
+            "name": "rightAileron",
+            "shortDesc": "Right Aileron",
+            "type": "float",
+            "units": "deg"
+        },
+        {
+            "name": "leftRuddervator",
+            "shortDesc": "Left Ruddervator",
+            "type": "float",
+            "units": "deg"
+        },
+        {
+            "name": "rightRuddervator",
+            "shortDesc": "Right Ruddervator",
+            "type": "float",
+            "units": "deg"
+        }
+    ]
+}

--- a/src/Vehicle/FactGroups/CustomTiltAngleFactGroup.cc
+++ b/src/Vehicle/FactGroups/CustomTiltAngleFactGroup.cc
@@ -6,6 +6,8 @@
 CustomTiltAngleFactGroup::CustomTiltAngleFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/CustomTiltAngleFactGroup.json", parent)
 {
+    setObjectName("CustomTiltAngleFactGroup");
+    
     _addFact(&_tiltFlFact, "tiltFl");
     _addFact(&_tiltFrFact, "tiltFr");
     _addFact(&_tiltRlFact, "tiltRl");
@@ -15,19 +17,22 @@ CustomTiltAngleFactGroup::CustomTiltAngleFactGroup(QObject* parent)
 void CustomTiltAngleFactGroup::handleMessage(Vehicle *vehicle, const mavlink_message_t &message) {
     switch (message.msgid) {
         case MAVLINK_MSG_ID_TILT_ANGLE: 
+            qDebug() << "Received MAVLINK_MSG_ID_TILT_ANGLE.";
             _handleTiltAngle(message);
             break;
             default:
             break;
     }
 }
+
 void CustomTiltAngleFactGroup::_handleTiltAngle(const mavlink_message_t &message) {
     mavlink_tilt_angle_t tiltCtrl{}; 
-    mavlink_msg_tilt_angle_decode(&message, &tiltCtrl); 
+    mavlink_msg_tilt_angle_decode(&message, &tiltCtrl);
     _updateTiltAngle(tiltCtrl.tilt_fl, tiltCtrl.tilt_fr, tiltCtrl.tilt_rl, tiltCtrl.tilt_rr);
 
     _setTelemetryAvailable(true); // FactGroup에 정의되어 있음
 }
+
 void CustomTiltAngleFactGroup::_updateTiltAngle(float fl, float fr, float rl, float rr) {
     _tiltFlFact.setRawValue(fl);
     _tiltFrFact.setRawValue(fr);

--- a/src/Vehicle/FactGroups/CustomTiltAngleFactGroup.json
+++ b/src/Vehicle/FactGroups/CustomTiltAngleFactGroup.json
@@ -7,25 +7,29 @@
     "name": "tiltFl",
     "shortDesc": "Front Left Tilt",
     "type": "float",
-    "units": "deg"
+    "units": "deg",
+    "decimalPlaces": 2
 },
 {
     "name": "tiltFr",
     "shortDesc": "Front Right Tilt",
     "type": "float",
-    "units": "deg"
+    "units": "deg",
+    "decimalPlaces": 2
 },
 {
     "name": "tiltRl",
     "shortDesc": "Rear Left Tilt",
     "type": "float",
-    "units": "deg"
+    "units": "deg",
+    "decimalPlaces": 2
 },
 {
     "name": "tiltRr",
     "shortDesc": "Rear Right Tilt",
     "type": "float",
-    "units": "deg"
+    "units": "deg",
+    "decimalPlaces": 2
 }
 ]
 }

--- a/src/Vehicle/FactGroups/EscHBCIFactGroup.cc
+++ b/src/Vehicle/FactGroups/EscHBCIFactGroup.cc
@@ -1,0 +1,98 @@
+#include "EscHBCIFactGroup.h"
+#include "mavlink.h"
+#include <mavlink/v2.0/development/mavlink_msg_esc_hbci_monitor.h>
+
+#include <QDebug>
+
+EscHBCIFactGroup::EscHBCIFactGroup(QObject* parent)
+    : FactGroup(1000, ":/json/Vehicle/EscHBCIFactGroup.json", parent)
+{
+    _addFact(&_voltageFl, "voltageFl");
+    _addFact(&_voltageFr, "voltageFr");
+    _addFact(&_voltageRl, "voltageRl");
+    _addFact(&_voltageRr, "voltageRr");
+
+    _addFact(&_currentFl, "currentFl");
+    _addFact(&_currentFr, "currentFr");
+    _addFact(&_currentRl, "currentRl");
+    _addFact(&_currentRr, "currentRr");
+
+    _addFact(&_rpmFl, "rpmFl");
+    _addFact(&_rpmFr, "rpmFr");
+    _addFact(&_rpmRl, "rpmRl");
+    _addFact(&_rpmRr, "rpmRr");
+
+    _addFact(&_motorTempFl, "motorTempFl");
+    _addFact(&_motorTempFr, "motorTempFr");
+    _addFact(&_motorTempRl, "motorTempRl");
+    _addFact(&_motorTempRr, "motorTempRr");
+
+    _addFact(&_escTempFl, "escTempFl");
+    _addFact(&_escTempFr, "escTempFr");
+    _addFact(&_escTempRl, "escTempRl");
+    _addFact(&_escTempRr, "escTempRr");
+
+    _addFact(&_outputPwmFl, "outputPwmFl");
+    _addFact(&_outputPwmFr, "outputPwmFr");
+    _addFact(&_outputPwmRl, "outputPwmRl");
+    _addFact(&_outputPwmRr, "outputPwmRr");
+
+    _addFact(&_inputPwmFl, "inputPwmFl");
+    _addFact(&_inputPwmFr, "inputPwmFr");
+    _addFact(&_inputPwmRl, "inputPwmRl");
+    _addFact(&_inputPwmRr, "inputPwmRr");
+}
+
+void EscHBCIFactGroup::handleMessage(Vehicle* vehicle, const mavlink_message_t& message)
+{
+    switch (message.msgid) {
+        case MAVLINK_MSG_ID_ESC_HBCI_MONITOR:
+            _handleEscHbciMonitor(message);
+            break;
+        default:
+            break;
+    }
+}
+
+void EscHBCIFactGroup::_handleEscHbciMonitor(const mavlink_message_t& message)
+{
+    mavlink_esc_hbci_monitor_t esc{};
+    mavlink_msg_esc_hbci_monitor_decode(&message, &esc);
+
+    _voltageFl.setRawValue(esc.voltage_fl);
+    _voltageFr.setRawValue(esc.voltage_fr);
+    _voltageRl.setRawValue(esc.voltage_rl);
+    _voltageRr.setRawValue(esc.voltage_rr);
+
+    _currentFl.setRawValue(esc.current_fl);
+    _currentFr.setRawValue(esc.current_fr);
+    _currentRl.setRawValue(esc.current_rl);
+    _currentRr.setRawValue(esc.current_rr);
+
+    _rpmFl.setRawValue(esc.rpm_fl);
+    _rpmFr.setRawValue(esc.rpm_fr);
+    _rpmRl.setRawValue(esc.rpm_rl);
+    _rpmRr.setRawValue(esc.rpm_rr);
+
+    _motorTempFl.setRawValue(esc.motor_temper_fl);
+    _motorTempFr.setRawValue(esc.motor_temper_fr);
+    _motorTempRl.setRawValue(esc.motor_temper_rl);
+    _motorTempRr.setRawValue(esc.motor_temper_rr);
+
+    _escTempFl.setRawValue(esc.esc_temper_fl);
+    _escTempFr.setRawValue(esc.esc_temper_fr);
+    _escTempRl.setRawValue(esc.esc_temper_rl);
+    _escTempRr.setRawValue(esc.esc_temper_rr);
+
+    _outputPwmFl.setRawValue(esc.output_pwm_fl);
+    _outputPwmFr.setRawValue(esc.output_pwm_fr);
+    _outputPwmRl.setRawValue(esc.output_pwm_rl);
+    _outputPwmRr.setRawValue(esc.output_pwm_rr);
+
+    _inputPwmFl.setRawValue(esc.input_pwm_fl);
+    _inputPwmFr.setRawValue(esc.input_pwm_fr);
+    _inputPwmRl.setRawValue(esc.input_pwm_rl);
+    _inputPwmRr.setRawValue(esc.input_pwm_rr);
+
+    _setTelemetryAvailable(true);
+}

--- a/src/Vehicle/FactGroups/EscHBCIFactGroup.h
+++ b/src/Vehicle/FactGroups/EscHBCIFactGroup.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "FactGroup.h"
+
+class EscHBCIFactGroup : public FactGroup
+{
+    Q_OBJECT
+
+    // QML에서 사용 가능한 속성 등록
+    Q_PROPERTY(Fact* voltageFl READ voltageFl CONSTANT)
+    Q_PROPERTY(Fact* voltageFr READ voltageFr CONSTANT)
+    Q_PROPERTY(Fact* voltageRl READ voltageRl CONSTANT)
+    Q_PROPERTY(Fact* voltageRr READ voltageRr CONSTANT)
+
+    Q_PROPERTY(Fact* currentFl READ currentFl CONSTANT)
+    Q_PROPERTY(Fact* currentFr READ currentFr CONSTANT)
+    Q_PROPERTY(Fact* currentRl READ currentRl CONSTANT)
+    Q_PROPERTY(Fact* currentRr READ currentRr CONSTANT)
+
+    Q_PROPERTY(Fact* rpmFl READ rpmFl CONSTANT)
+    Q_PROPERTY(Fact* rpmFr READ rpmFr CONSTANT)
+    Q_PROPERTY(Fact* rpmRl READ rpmRl CONSTANT)
+    Q_PROPERTY(Fact* rpmRr READ rpmRr CONSTANT)
+
+    Q_PROPERTY(Fact* motorTempFl READ motorTempFl CONSTANT)
+    Q_PROPERTY(Fact* motorTempFr READ motorTempFr CONSTANT)
+    Q_PROPERTY(Fact* motorTempRl READ motorTempRl CONSTANT)
+    Q_PROPERTY(Fact* motorTempRr READ motorTempRr CONSTANT)
+
+    Q_PROPERTY(Fact* escTempFl READ escTempFl CONSTANT)
+    Q_PROPERTY(Fact* escTempFr READ escTempFr CONSTANT)
+    Q_PROPERTY(Fact* escTempRl READ escTempRl CONSTANT)
+    Q_PROPERTY(Fact* escTempRr READ escTempRr CONSTANT)
+
+    Q_PROPERTY(Fact* outputPwmFl READ outputPwmFl CONSTANT)
+    Q_PROPERTY(Fact* outputPwmFr READ outputPwmFr CONSTANT)
+    Q_PROPERTY(Fact* outputPwmRl READ outputPwmRl CONSTANT)
+    Q_PROPERTY(Fact* outputPwmRr READ outputPwmRr CONSTANT)
+
+    Q_PROPERTY(Fact* inputPwmFl READ inputPwmFl CONSTANT)
+    Q_PROPERTY(Fact* inputPwmFr READ inputPwmFr CONSTANT)
+    Q_PROPERTY(Fact* inputPwmRl READ inputPwmRl CONSTANT)
+    Q_PROPERTY(Fact* inputPwmRr READ inputPwmRr CONSTANT)
+
+public:
+    explicit EscHBCIFactGroup(QObject* parent = nullptr);
+
+    // Getter 함수들
+    Fact* voltageFl()     { return &_voltageFl; }
+    Fact* voltageFr()     { return &_voltageFr; }
+    Fact* voltageRl()     { return &_voltageRl; }
+    Fact* voltageRr()     { return &_voltageRr; }
+
+    Fact* currentFl()     { return &_currentFl; }
+    Fact* currentFr()     { return &_currentFr; }
+    Fact* currentRl()     { return &_currentRl; }
+    Fact* currentRr()     { return &_currentRr; }
+
+    Fact* rpmFl()         { return &_rpmFl; }
+    Fact* rpmFr()         { return &_rpmFr; }
+    Fact* rpmRl()         { return &_rpmRl; }
+    Fact* rpmRr()         { return &_rpmRr; }
+
+    Fact* motorTempFl()   { return &_motorTempFl; }
+    Fact* motorTempFr()   { return &_motorTempFr; }
+    Fact* motorTempRl()   { return &_motorTempRl; }
+    Fact* motorTempRr()   { return &_motorTempRr; }
+
+    Fact* escTempFl()     { return &_escTempFl; }
+    Fact* escTempFr()     { return &_escTempFr; }
+    Fact* escTempRl()     { return &_escTempRl; }
+    Fact* escTempRr()     { return &_escTempRr; }
+
+    Fact* outputPwmFl()   { return &_outputPwmFl; }
+    Fact* outputPwmFr()   { return &_outputPwmFr; }
+    Fact* outputPwmRl()   { return &_outputPwmRl; }
+    Fact* outputPwmRr()   { return &_outputPwmRr; }
+
+    Fact* inputPwmFl()    { return &_inputPwmFl; }
+    Fact* inputPwmFr()    { return &_inputPwmFr; }
+    Fact* inputPwmRl()    { return &_inputPwmRl; }
+    Fact* inputPwmRr()    { return &_inputPwmRr; }
+
+    void handleMessage(Vehicle* vehicle, const mavlink_message_t& message) override;
+
+protected:
+    void _handleEscHbciMonitor(const mavlink_message_t& message);
+
+private:
+    // Fact 객체 선언
+    Fact _voltageFl, _voltageFr, _voltageRl, _voltageRr;
+    Fact _currentFl, _currentFr, _currentRl, _currentRr;
+    Fact _rpmFl, _rpmFr, _rpmRl, _rpmRr;
+    Fact _motorTempFl, _motorTempFr, _motorTempRl, _motorTempRr;
+    Fact _escTempFl, _escTempFr, _escTempRl, _escTempRr;
+    Fact _outputPwmFl, _outputPwmFr, _outputPwmRl, _outputPwmRr;
+    Fact _inputPwmFl, _inputPwmFr, _inputPwmRl, _inputPwmRr;
+};

--- a/src/Vehicle/FactGroups/EscHBCIFactGroup.json
+++ b/src/Vehicle/FactGroups/EscHBCIFactGroup.json
@@ -1,0 +1,40 @@
+{
+    "version":      1,
+    "fileType":     "FactMetaData",
+    "QGC.MetaData.Facts": [
+        { "name": "voltageFl",       "shortDesc": "Voltage Front Left",      "type": "float",   "units": "V" },
+        { "name": "voltageFr",       "shortDesc": "Voltage Front Right",     "type": "float",   "units": "V" },
+        { "name": "voltageRl",       "shortDesc": "Voltage Rear Left",       "type": "float",   "units": "V" },
+        { "name": "voltageRr",       "shortDesc": "Voltage Rear Right",      "type": "float",   "units": "V" },
+
+        { "name": "currentFl",       "shortDesc": "Current Front Left",      "type": "float",   "units": "A" },
+        { "name": "currentFr",       "shortDesc": "Current Front Right",     "type": "float",   "units": "A" },
+        { "name": "currentRl",       "shortDesc": "Current Rear Left",       "type": "float",   "units": "A" },
+        { "name": "currentRr",       "shortDesc": "Current Rear Right",      "type": "float",   "units": "A" },
+
+        { "name": "rpmFl",           "shortDesc": "RPM Front Left",          "type": "int32",   "units": "RPM" },
+        { "name": "rpmFr",           "shortDesc": "RPM Front Right",         "type": "int32",   "units": "RPM" },
+        { "name": "rpmRl",           "shortDesc": "RPM Rear Left",           "type": "int32",   "units": "RPM" },
+        { "name": "rpmRr",           "shortDesc": "RPM Rear Right",          "type": "int32",   "units": "RPM" },
+
+        { "name": "motorTempFl",     "shortDesc": "Motor Temp Front Left",   "type": "int32",   "units": "degC" },
+        { "name": "motorTempFr",     "shortDesc": "Motor Temp Front Right",  "type": "int32",   "units": "degC" },
+        { "name": "motorTempRl",     "shortDesc": "Motor Temp Rear Left",    "type": "int32",   "units": "degC" },
+        { "name": "motorTempRr",     "shortDesc": "Motor Temp Rear Right",   "type": "int32",   "units": "degC" },
+
+        { "name": "escTempFl",       "shortDesc": "ESC Temp Front Left",     "type": "int32",   "units": "degC" },
+        { "name": "escTempFr",       "shortDesc": "ESC Temp Front Right",    "type": "int32",   "units": "degC" },
+        { "name": "escTempRl",       "shortDesc": "ESC Temp Rear Left",      "type": "int32",   "units": "degC" },
+        { "name": "escTempRr",       "shortDesc": "ESC Temp Rear Right",     "type": "int32",   "units": "degC" },
+
+        { "name": "outputPwmFl",     "shortDesc": "Output PWM Front Left",   "type": "float",   "units": "%" },
+        { "name": "outputPwmFr",     "shortDesc": "Output PWM Front Right",  "type": "float",   "units": "%" },
+        { "name": "outputPwmRl",     "shortDesc": "Output PWM Rear Left",    "type": "float",   "units": "%" },
+        { "name": "outputPwmRr",     "shortDesc": "Output PWM Rear Right",   "type": "float",   "units": "%" },
+
+        { "name": "inputPwmFl",      "shortDesc": "Input PWM Front Left",    "type": "float",   "units": "%" },
+        { "name": "inputPwmFr",      "shortDesc": "Input PWM Front Right",   "type": "float",   "units": "%" },
+        { "name": "inputPwmRl",      "shortDesc": "Input PWM Rear Left",     "type": "float",   "units": "%" },
+        { "name": "inputPwmRr",      "shortDesc": "Input PWM Rear Right",    "type": "float",   "units": "%" }
+    ]
+}

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -121,6 +121,9 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _fakeFactGroup (this)
     , _tiltAngleFactGroup (this)
     , _terrainProtocolHandler       (new TerrainProtocolHandler(this, &_terrainFactGroup, this))
+    , _controlSurfaceCmdFactGroup(this)
+    , _escHbciFactGroup(this)
+
 {
     connect(JoystickManager::instance(), &JoystickManager::activeJoystickChanged, this, &Vehicle::_loadJoystickSettings);
     connect(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged, this, &Vehicle::_activeVehicleChanged);
@@ -224,6 +227,9 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _localPositionSetpointFactGroup   (this)
     , _fakeFactGroup (this)
     , _tiltAngleFactGroup (this)
+    , _controlSurfaceCmdFactGroup(this)
+    , _escHbciFactGroup(this)
+    
 {
     // This will also set the settings based firmware/vehicle types. So it needs to happen first.
     if (_firmwareType == MAV_AUTOPILOT_TRACK) {
@@ -346,6 +352,8 @@ void Vehicle::_commonInit()
 
     _addFactGroup(&_fakeFactGroup, _fakeFactGroupName);
     _addFactGroup(&_tiltAngleFactGroup, _tiltAngleFactGroupName);
+    _addFactGroup(&_controlSurfaceCmdFactGroup, _controlSurfaceCmdFactGroupName);
+    _addFactGroup(&_escHbciFactGroup, _escHbciFactGroupName);
 
     // Add firmware-specific fact groups, if provided
     QMap<QString, FactGroup*>* fwFactGroups = _firmwarePlugin->factGroups();

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -49,6 +49,10 @@
 #include "FakeFactGroup.h"
 #include "CustomTiltAngleFactGroup.h"
 
+#include "FactGroups/ControlSurfaceCmdFactGroup.h"
+
+#include "FactGroups/EscHBCIFactGroup.h"
+
 class Actuators;
 class AutoPilotPlugin;
 class Autotune;
@@ -255,6 +259,8 @@ public:
 
     // FactGroup object model properties
 
+    Q_PROPERTY(FactGroup*           escHbci           READ escHbciFactGroup         CONSTANT)
+    Q_PROPERTY(FactGroup*           controlSurfaceCmd READ controlSurfaceCmdFactGroup    CONSTANT)
     Q_PROPERTY(FactGroup*           tiltAngle         READ tiltAngleFactGroup           CONSTANT)
     Q_PROPERTY(FactGroup*           fake         READ fakeFactGroup           CONSTANT)
     Q_PROPERTY(FactGroup*           vehicle         READ vehicleFactGroup           CONSTANT)
@@ -618,6 +624,8 @@ public:
 
     FactGroup* fakeFactGroup () { return &_fakeFactGroup; }
     FactGroup* tiltAngleFactGroup () { return &_tiltAngleFactGroup; }
+    FactGroup* controlSurfaceCmdFactGroup() { return &_controlSurfaceCmdFactGroup; }
+    FactGroup* escHbciFactGroup() { return &_escHbciFactGroup; }
     QmlObjectListModel* batteries           () { return &_batteryFactGroupListModel; }
 
     MissionManager*                 missionManager      () { return _missionManager; }
@@ -1262,6 +1270,8 @@ private:
 
     const QString _fakeFactGroupName = QStringLiteral("fake");
     const QString _tiltAngleFactGroupName = QStringLiteral("tiltAngle");
+    const QString _controlSurfaceCmdFactGroupName = QStringLiteral("controlSurfaceCmd");
+    const QString _escHbciFactGroupName = QStringLiteral("escHbci");
 
     VehicleFactGroup*               _vehicleFactGroup;
     VehicleGPSFactGroup             _gpsFactGroup;
@@ -1284,6 +1294,8 @@ private:
 
     FakeFactGroup _fakeFactGroup;
     CustomTiltAngleFactGroup _tiltAngleFactGroup;
+    ControlSurfaceCmdFactGroup _controlSurfaceCmdFactGroup;
+    EscHBCIFactGroup _escHbciFactGroup;
     
     QmlObjectListModel              _batteryFactGroupListModel;
 


### PR DESCRIPTION
### ✅ 주요 변경 사항

이번 PR에서는 QGC 계기판에 다음 두 가지 기능을 추가했습니다:

1. **ESC_HBCI_MONITOR 메시지 기반 HUD 추가**
   - `EscHBCIFactGroup` 정의 (총 29개 필드 수신)
   - QML 연동: `EscHBCIHUD.qml` 구현
   - MAVLink 메시지 ID 515 (`mavlink_msg_esc_hbci_monitor`) 처리
   - 향후 배열 기반 전환을 위한 구조 고려

2. **CONTROL_SURFACE_CMD 메시지 기반 HUD 추가**
   - `ControlSurfaceCmdFactGroup` 정의
   - QML 연동: `ControlSurfaceHUD.qml` 구현
   - actuator command 수신 및 시각화 기능 추가

---

### 🧱 변경된 주요 파일

- `src/Vehicle/FactGroups/EscHBCIFactGroup.{h,cc,json}`
- `src/Vehicle/FactGroups/ControlSurfaceCmdFactGroup.{h,cc,json}`
- `src/FlightDisplay/EscHBCIHUD.qml`
- `src/FlightDisplay/ControlSurfaceHUD.qml`
- `qgroundcontrol.qrc`, `CMakeLists.txt`, `Vehicle.h`, `Vehicle.cc` 등 등록 관련 파일